### PR TITLE
Remove duplicate import vars

### DIFF
--- a/src/html2js.ts
+++ b/src/html2js.ts
@@ -141,7 +141,7 @@ interface AnalysisConverterOptions {
   /**
    * Namespace references (ie, Polymer.DomModule) to "exclude"" be replacing
    * the entire reference with `undefined`.
-   * 
+   *
    * These references would normally be rewritten to module imports, but in some
    * cases they are accessed without importing. The presumption is that access
    * is guarded by a conditional and replcing with `undefined` will safely
@@ -255,7 +255,7 @@ class DocumentConverter {
   /**
    * Returns the HTML Imports of a document, except imports to documents
    * specifically excluded in the AnalysisConverter.
-   * 
+   *
    * Note: Imports that are not found are not returned by the analyzer.
    */
   getHtmlImports() {
@@ -442,7 +442,7 @@ class DocumentConverter {
                 const jsModule = analysisConverter.modules.get(moduleExport.url)!;
                 path.replace(jsc.identifier(getModuleId(jsModule.url)));
               } else {
-                path.replace(jsc.identifier(moduleExport.name));
+                path.replace(jsc.identifier(getImportAlias(moduleExport.name)));
               }
             }
           }
@@ -454,14 +454,14 @@ class DocumentConverter {
 
   /**
    * Rewrites local references to a namespace member, ie:
-   * 
+   *
    * const NS = {
    *   foo() {}
    * }
    * NS.foo();
-   * 
+   *
    * to:
-   * 
+   *
    * export foo() {}
    * foo();
    */
@@ -497,7 +497,7 @@ class DocumentConverter {
             if (s === '*') {
               return jsc.importNamespaceSpecifier(jsc.identifier(getModuleId(jsUrl)));
             } else {
-              return jsc.importSpecifier(jsc.identifier(s));
+              return jsc.importSpecifier(jsc.identifier(s), jsc.identifier(getImportAlias(s)));
             }
           })
           : [];
@@ -709,11 +709,23 @@ function htmlUrlToJs(url: string, from?: string): string {
   return jsUrl;
 }
 
+/**
+ * Get the import alias for an imported member. Useful when generating an
+ * import statement or a reference to an imported member.
+ */
+function getImportAlias(importId: string) {
+  return '$' + importId;
+}
+
+/**
+ * Get the import name for an imported module object. Useful when generating an
+ * import statement, or a reference to an imported module object.
+ */
 function getModuleId(url: string) {
   const baseName = path.basename(url);
   const lastDotIndex = baseName.lastIndexOf('.');
   const mainName = baseName.substring(0, lastDotIndex);
-  return '$' + dashToCamelCase(mainName);
+  return '$$' + dashToCamelCase(mainName);
 }
 
 function dashToCamelCase(s: string) {

--- a/src/test/html2js_test.ts
+++ b/src/test/html2js_test.ts
@@ -184,8 +184,8 @@ export const arrow = () => {
       });
       const converted = await getConverted();
       const js = converted.get('./test.js');
-      assert.equal(js, `import { Element } from './dep.js';
-class MyElement extends Element {
+      assert.equal(js, `import { Element as $Element } from './dep.js';
+class MyElement extends $Element {
 }\n`);
     });
 
@@ -210,8 +210,8 @@ class MyElement extends Element {
       });
       const converted = await getConverted();
       const js = converted.get('./test.js');
-      assert.equal(js, `import { Element } from './dep.js';
-class MyElement extends Element {
+      assert.equal(js, `import { Element as $Element } from './dep.js';
+class MyElement extends $Element {
 }\n`);
     });
 
@@ -237,8 +237,8 @@ class MyElement extends Element {
       });
       const converted = await getConverted();
       const js = converted.get('./test.js');
-      assert.equal(js, `import * as $dep from './dep.js';
-const Foo = $dep;
+      assert.equal(js, `import * as $$dep from './dep.js';
+const Foo = $$dep;
 class MyElement extends Foo.Element {
 }\n`);
     });
@@ -290,8 +290,8 @@ export const isDeep = isPath;
       });
       const converted = await converter.convert();
       const js = converted.get('./test.js');
-      assert.equal(js, `import { Element } from './dep.js';
-class MyElement extends Element {
+      assert.equal(js, `import { Element as $Element } from './dep.js';
+class MyElement extends $Element {
 }\n`);
     });
 
@@ -355,7 +355,7 @@ class MyElement extends Element {
       const program = esprima.parse(source);
       const statement = program.body[0] as estree.ExpressionStatement;
       const expression = statement.expression as estree.AssignmentExpression;
-      return expression.left as estree.MemberExpression;      
+      return expression.left as estree.MemberExpression;
     }
 
     test('works for a single property access', () => {


### PR DESCRIPTION
Quick fix to create new aliases for all imports. Follows one standard format for simplicity.

### Source

```html
<link rel="import" href="../utils/resolve-url.html">
<link rel="import" href="legacy-element-mixin.html">

<script>
  let LegacyElementMixin = Polymer.LegacyElementMixin;
  let klass = LegacyElementMixin(klass);
  // ... 
```

### Before

```js
import * as $resolveUrl from '../utils/resolve-url.js';
import { LegacyElementMixin } from './legacy-element-mixin.js';

let LegacyElementMixin = LegacyElementMixin; // BROKEN
let klass = LegacyElementMixin(klass);
```
 
### After

```js
import * as $$resolveUrl from '../utils/resolve-url.js';
import { LegacyElementMixin as $LegacyElementMixin } from './legacy-element-mixin.js';

let LegacyElementMixin = $LegacyElementMixin; // WORKS!
let klass = LegacyElementMixin(klass);
```

---

/cc @justinfagnani @usergenic 