### PR TITLE
Alias all imports to avoid common user-created alias conflicts

### DIFF
--- a/src/html2js.ts
+++ b/src/html2js.ts
@@ -293,8 +293,8 @@ class DocumentConverter {
         const {namespace, value} = exported;
         const namespaceName = namespace.join('.');
 
-        if (this.isNamespace(statement)) {
-          this.rewriteNamespace(namespaceName, value, statement);
+        if (this.isNamespace(statement) && value.type === 'ObjectExpression') {
+          this.rewriteNamespaceObject(namespaceName, value, statement);
         } else if (value.type === 'Identifier') {
           // An 'export' of the form:
           // Polymer.Foo = Foo;
@@ -320,7 +320,7 @@ class DocumentConverter {
               nsNode = nsParent.expression.right as ObjectExpression;
             }
 
-            this.rewriteNamespace(namespaceName, nsNode, nsParent);
+            this.rewriteNamespaceObject(namespaceName, nsNode, nsParent);
 
             // Remove the namespace assignment
             this.program.body.splice(this.currentStatementIndex, 1);
@@ -539,13 +539,8 @@ class DocumentConverter {
    * @param body the ObjectExpression body of the namespace
    * @param statement the statement, to be replaced, that contains the namespace
    */
-  rewriteNamespace(name: string, body: Node, statement: Statement) {
-    if (body.type !== 'ObjectExpression') {
-      console.warn('unable to handle non-object namespace', this.document.url, body.loc);
-      return;
-    }
-
-    const exports = getNamespaceExports(body as ObjectExpression);
+  rewriteNamespaceObject(name: string, body: ObjectExpression, statement: Statement) {
+    const exports = getNamespaceExports(body);
 
     // Replace original namespace statement with new exports
     const nsIndex = this.program.body.indexOf(statement);

--- a/src/test/html2js_test.ts
+++ b/src/test/html2js_test.ts
@@ -148,6 +148,109 @@ export const arrow = () => {
 `);
     });
 
+    test.skip('exports a namespace object and fixes local references to its properties', async () => {
+      setSources({
+        'test.html': `
+          <script>
+            (function() {
+              'use strict';
+              /**
+               * @namespace
+               */
+              Polymer.Namespace = {
+                obj: {},
+                meth() {},
+                func: function() {
+                  return Polymer.meth();
+                },
+                arrow: () => {}
+              };
+            })();
+          </script>`,
+      });
+      assert.equal(await getJs(), `export const obj = {};
+export function meth() {
+}
+export function func() {
+  return meth();
+}
+export const arrow = () => {
+};
+`);
+    });
+
+    test('exports a namespace function and its properties', async () => {
+      setSources({
+        'test.html': `
+          <script>
+            (function() {
+              'use strict';
+              /**
+               * @namespace
+               * @memberof Polymer
+               */
+              Polymer.dom = function() {
+                return 'Polymer.dom result';
+              };
+              /**
+               * @memberof Polymer.dom
+               */
+              Polymer.dom.subFn = function() {
+                return 'Polymer.dom.subFn result';
+              };
+            })();
+          </script>`,
+      });
+      assert.equal(await getJs(), `export const dom = function () {
+  return \'Polymer.dom result\';
+};
+export const subFn = function () {
+  return \'Polymer.dom.subFn result\';
+};
+`);
+    });
+
+    test.skip('exports a namespace function and fixes references to its properties', async () => {
+      setSources({
+        'test.html': `
+          <script>
+            (function() {
+              'use strict';
+              /**
+               * @namespace
+               * @memberof Polymer
+               */
+              Polymer.dom = function() {
+                return 'Polymer.dom result';
+              };
+              /**
+               * @memberof Polymer.dom
+               */
+              Polymer.dom.subFn = function() {
+                return 'Polymer.dom.subFn result';
+              };
+              /**
+               * @memberof Polymer.dom
+               */
+              Polymer.dom.subFnDelegate = function() {
+                return 'Polymer.dom.subFnDelegate delegates: ' + Polymer.dom() + Polymer.dom.subFn();
+              };
+            })();
+          </script>`,
+      });
+      assert.equal(await getJs(), `export const dom = function () {
+    return \'Polymer.dom result\';
+};
+export const subFn = function () {
+    return \'Polymer.dom.subFn result\';
+};
+export const subFnDelegate = function () {
+    return \'Polymer.dom.subFnDelegate delegates: \' + dom() + subFn();
+};
+`);
+    });
+
+
     test('exports a referenced namespace', async () => {
       setSources({
         'test.html': `


### PR DESCRIPTION
Quick fix to create new aliases for all imports. Follows one standard format for simplicity.

### Source

```html
<link rel="import" href="../utils/resolve-url.html">
<link rel="import" href="legacy-element-mixin.html">

<script>
  let LegacyElementMixin = Polymer.LegacyElementMixin;
  let klass = LegacyElementMixin(klass);
  // ... 
```

### Before

```js
import * as $resolveUrl from '../utils/resolve-url.js';
import { LegacyElementMixin } from './legacy-element-mixin.js';

let LegacyElementMixin = LegacyElementMixin; // BROKEN
let klass = LegacyElementMixin(klass);
```
 
### After

```js
import * as $$resolveUrl from '../utils/resolve-url.js';
import { LegacyElementMixin as $LegacyElementMixin } from './legacy-element-mixin.js';

let LegacyElementMixin = $LegacyElementMixin; // WORKS!
let klass = LegacyElementMixin(klass);
```

---

/cc @justinfagnani @usergenic 