### PR TITLE
fix exporting of members that were defined outside of namespace

### DIFF
--- a/src/html2js.ts
+++ b/src/html2js.ts
@@ -576,7 +576,7 @@ function getNamespaceExports(namespace: ObjectExpression) {
 
   for (const {key, value}  of namespace.properties) {
     const name = (key as Identifier).name;
-    if (value.type === 'ObjectExpression') {
+    if (['ObjectExpression', 'ArrayExpression', 'Literal'].includes(value.type)) {
       exports.push({
         name,
         node: jsc.exportNamedDeclaration(
@@ -613,6 +613,8 @@ function getNamespaceExports(namespace: ObjectExpression) {
           [jsc.exportSpecifier(jsc.identifier(name), jsc.identifier(name))]
         ),
       });
+    } else {
+      console.warn('Namespace property not handled:', name, value);
     }
   }
 

--- a/src/test/html2js_test.ts
+++ b/src/test/html2js_test.ts
@@ -137,6 +137,8 @@ suite('html2js', () => {
                * @memberof Polymer
                */
               Polymer.Namespace = {
+                literal: 42,
+                arr: [],
                 obj: {},
                 meth() {},
                 func: function() {},
@@ -154,6 +156,8 @@ function independentFn() {
     * @namespace
     * @memberof Polymer
     */
+export const literal = 42;
+export const arr = [];
 export const obj = {};
 export function meth() {
 }


### PR DESCRIPTION
See test for a summary of the change.
Fixes `util/resolve-url.js`