### PR TITLE
stop removing dom module for now

### DIFF
--- a/src/html2js.ts
+++ b/src/html2js.ts
@@ -110,9 +110,8 @@ export async function convertPackage() {
   const converter = new AnalysisConverter(analysis, {
     excludes: [
       'lib/utils/boot.html',
-      'lib/elements/dom-module.html',
     ],
-    referenceExcludes: ['Polymer.DomModule'],
+    referenceExcludes: [],
   });
 
   try {


### PR DESCRIPTION
At this point, `undefined.import()` is causing more trouble than if DomModule was just included. Treating DomModule like any other file would be less trouble until we're ready to remove it.