### PR TITLE
configure mutable exports

### DIFF
--- a/src/html2js.ts
+++ b/src/html2js.ts
@@ -115,6 +115,9 @@ export async function convertPackage() {
       'lib/elements/dom-module.html',
     ],
     referenceExcludes: ['Polymer.DomModule'],
+    mutableExports: {
+      'Polymer.telemetry': ['instanceCount'],
+    },
   });
 
   try {
@@ -133,7 +136,7 @@ export async function convertPackage() {
   }
 }
 
-interface AnalysisConverterOptions {
+export interface AnalysisConverterOptions {
   /**
    * Files to exclude from conversion (ie lib/utils/boot.html). Imports
    * to these files are also excluded.
@@ -150,6 +153,14 @@ interface AnalysisConverterOptions {
    * fail the guard.
    */
   referenceExcludes?: string[];
+
+  /**
+   * For each namespace you can set a list of references (ie,
+   * 'Polymer.telemetry.instanceCount') that need to be mutable and cannot be
+   * exported as `const` variables. They will be exported as `let` variables
+   * instead.
+   */
+  mutableExports?: {[namespaceName: string]: string[]};
 }
 
 /**
@@ -226,9 +237,11 @@ class DocumentConverter {
   scriptDocument: Document;
   program: Program;
   currentStatementIndex = 0;
+  _mutableExports: {[namespaceName: string]: string[]};
 
   constructor(analysisConverter: AnalysisConverter, document: Document) {
     this.analysisConverter = analysisConverter;
+    this._mutableExports = <any>Object.assign({}, this.analysisConverter.options.mutableExports);
     this.document = document;
     this.jsUrl = htmlUrlToJs(document.url);
     this.module = {
@@ -574,7 +587,8 @@ class DocumentConverter {
    * @param statement the statement, to be replaced, that contains the namespace
    */
   rewriteNamespaceObject(name: string, body: ObjectExpression, statement: Statement) {
-    const exports = getNamespaceExports(body);
+    const mutableExports = this._mutableExports[name];
+    const exports = getNamespaceExports(body, mutableExports);
 
     // Replace original namespace statement with new exports
     const nsIndex = this.program.body.indexOf(statement);
@@ -621,7 +635,7 @@ class DocumentConverter {
 /**
  * Returns export declarations for each of a namespace objects members.
  */
-function getNamespaceExports(namespace: ObjectExpression) {
+function getNamespaceExports(namespace: ObjectExpression, mutableExports?: string[]) {
   const exports: {name: string, node: Node}[] = [];
 
   for (const {key, value}  of namespace.properties) {
@@ -631,11 +645,12 @@ function getNamespaceExports(namespace: ObjectExpression) {
     }
     const name = (key as Identifier).name;
     if (value.type === 'ObjectExpression' || value.type === 'ArrayExpression' || value.type === 'Literal') {
+      const isMutable = !!(mutableExports && mutableExports.includes(name));
       exports.push({
         name,
         node: jsc.exportNamedDeclaration(
           jsc.variableDeclaration(
-            'const',
+            isMutable ? 'let' : 'const',
             [jsc.variableDeclarator(key, value)]))
       });
     } else if (value.type === 'FunctionExpression') {

--- a/src/test/html2js_test.ts
+++ b/src/test/html2js_test.ts
@@ -3,7 +3,7 @@ import * as estree from 'estree';
 import * as path from 'path';
 
 import {Analyzer, FSUrlLoader, InMemoryOverlayUrlLoader, Document, UrlLoader, UrlResolver, PackageUrlResolver} from 'polymer-analyzer';
-import {AnalysisConverter, getMemberPath} from '../html2js';
+import {AnalysisConverter, AnalysisConverterOptions, getMemberPath} from '../html2js';
 import {assert} from 'chai';
 
 suite('html2js', () => {
@@ -20,10 +20,10 @@ suite('html2js', () => {
       })
     });
 
-    async function getJs() {
+    async function getJs(options?: AnalysisConverterOptions) {
       const analysis = await analyzer.analyze(['test.html']);
       const testDoc = analysis.getDocument('test.html') as Document;
-      const converter = new AnalysisConverter(analysis);
+      const converter = new AnalysisConverter(analysis, options);
       converter.convertDocument(testDoc);
       const module = converter.modules.get('./test.js');
       return module && module.source
@@ -110,7 +110,7 @@ suite('html2js', () => {
       assert.equal(await getJs(), `export const version = '2.0.0';\n`);
     });
 
-    test('exports the result of a funciton call', async () => {
+    test('exports the result of a function call', async () => {
       urlLoader.urlContentsMap.set('test.html', `
           <script>
             Polymer.LegacyElementMixin = Polymer.dedupingMixin();
@@ -193,6 +193,37 @@ export function thisReferenceFn() {
 }
 `);
     });
+
+    test('exports a mutable reference if set via mutableExports', async () => {
+      setSources({
+        'test.html': `
+          <script>
+            (function() {
+              'use strict';
+              /**
+               * @namespace
+               */
+              Polymer.Namespace = {
+                immutableLiteral: 42,
+                mutableLiteral: 0,
+                increment() {
+                  Polymer.Namespace.mutableLiteral++;
+                },
+              };
+            })();
+          </script>`,
+      });
+      assert.equal(await getJs({
+        mutableExports: {'Polymer.Namespace': ['mutableLiteral']}
+      }), `export const immutableLiteral = 42;
+export let mutableLiteral = 0;
+
+export function increment() {
+  mutableLiteral++;
+}
+`);
+    });
+
 
     test('exports a namespace function and its properties', async () => {
       setSources({


### PR DESCRIPTION
Some variables in Polymer need to be mutable. We can expect our users will have similar needs. This adds support for whitelisting certain exports as mutable, to be exported as `let`s.

See added test for summary of new support.

Fixes call to `$instanceCount++` in Polymer.