### PR TITLE
Fix guarded bad references to Polymer object

### DIFF
--- a/src/html2js.ts
+++ b/src/html2js.ts
@@ -116,7 +116,11 @@ export async function convertPackage() {
       'lib/utils/boot.html',
       'lib/elements/dom-module.html',
     ],
-    referenceExcludes: ['Polymer.DomModule'],
+    referenceExcludes: [
+      'Polymer.DomModule',
+      'Polymer.log',
+      'Polymer.sanitizeDOMValue'
+    ],
     mutableExports: {
       'Polymer.telemetry': ['instanceCount'],
     },


### PR DESCRIPTION
This is a temporary fix for two Polymer property references that currently need to be hand-fixed. Of the 4, these two are always hidden behind a conditional check, which means the naive change to undefined works great.

When we have a better solution to global config, we can fix these along with `Polymer.rootPath` & `Polymer.Settings`.