### PR TITLE
Simplify the interface between document converter and analysis converter

### DIFF
--- a/src/analysis-converter.ts
+++ b/src/analysis-converter.ts
@@ -17,7 +17,8 @@ import {Expression} from 'estree';
 import * as parse5 from 'parse5';
 import {Analysis, Document} from 'polymer-analyzer';
 
-import {DocumentConverter, ExportMigrationRecord} from './document-converter';
+import {DocumentConverter} from './document-converter';
+import {JsExport, JsModule} from './js-module';
 import {htmlUrlToJs} from './url-converter';
 
 const _isInTestRegex = /(\b|\/|\\)(test)(\/|\\)/;
@@ -27,40 +28,6 @@ const _isInBowerRegex = /(\b|\/|\\)(bower_components)(\/|\\)/;
 const _isInNpmRegex = /(\b|\/|\\)(node_modules)(\/|\\)/;
 const isNotExternal = (d: Document) =>
     !_isInBowerRegex.test(d.url) && !_isInNpmRegex.test(d.url);
-
-export interface JsExport {
-  /**
-   * URL of the JS module.
-   */
-  readonly url: string;
-
-  /**
-   * Exported name, ie Foo for `export Foo`;
-   *
-   * The name * represents the entire module, for when the key in the
-   * namespacedExports Map represents a namespace object.
-   */
-  readonly name: string;
-}
-
-export interface JsModule {
-  /**
-   * Package-relative URL of the converted JS module.
-   */
-  readonly url: string;
-
-  /**
-   * Converted source of the JS module.
-   */
-  readonly source: string;
-
-  /**
-   * Set of exported names.
-   */
-  readonly es6Exports: ReadonlySet<string>;
-
-  readonly exportMigrationRecords: ReadonlyArray<ExportMigrationRecord>;
-}
 
 export interface AnalysisConverterOptions {
   /**
@@ -75,7 +42,7 @@ export interface AnalysisConverterOptions {
    * Files to exclude from conversion (ie lib/utils/boot.html). Imports
    * to these files are also excluded.
    */
-  readonly excludes?: ReadonlyArray<string>;
+  readonly excludes?: Iterable<string>;
 
   /**
    * Namespace references (ie, Polymer.DomModule) to "exclude"" be replacing
@@ -86,7 +53,7 @@ export interface AnalysisConverterOptions {
    * is guarded by a conditional and replcing with `undefined` will safely
    * fail the guard.
    */
-  readonly referenceExcludes?: ReadonlyArray<string>;
+  readonly referenceExcludes?: Iterable<string>;
 
   /**
    * For each namespace you can set a list of references (ie,
@@ -182,10 +149,10 @@ export class AnalysisConverter {
     if (this.modules.has(jsUrl)) {
       return;
     }
-    const jsModule = new DocumentConverter(this, document).convert();
-    if (jsModule) {
+    const jsModules = new DocumentConverter(this, document).convert();
+    for (const jsModule of jsModules) {
       this.modules.set(jsModule.url, jsModule);
-      for (const expr of jsModule.exportMigrationRecords) {
+      for (const expr of jsModule.exportedNamespaceMembers) {
         this.namespacedExports.set(
             expr.oldNamespacedName,
             {name: expr.es6ExportName, url: jsModule.url});

--- a/src/js-module.ts
+++ b/src/js-module.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export interface JsModule {
+  /**
+   * Package-relative URL of the converted JS module.
+   */
+  readonly url: string;
+
+  /**
+   * Converted source of the JS module.
+   */
+  readonly source: string;
+
+  /**
+   * Set of exported names.
+   */
+  readonly es6Exports: ReadonlySet<string>;
+
+  readonly exportedNamespaceMembers: ReadonlyArray<NamespaceMemberToExport>;
+}
+
+export interface JsExport {
+  /**
+   * URL of the JS module.
+   */
+  readonly url: string;
+
+  /**
+   * Exported name, ie Foo for `export Foo`;
+   *
+   * The name * represents the entire module, for when the key in the
+   * namespacedExports Map represents a namespace object.
+   */
+  readonly name: string;
+}
+
+export interface NamespaceMemberToExport {
+  oldNamespacedName: string;
+  es6ExportName: string;
+}


### PR DESCRIPTION
This is a noop cleanup change.

At a high level there's two pieces: 
 - `DocumentConverter` no longer does any mutation of anything on `AnalysisConverter`, instead it returns an object and `AnalysisConverter` does its own mutation.
 - `DocumentConverter#convert()` now passes the `this.module` state around explicitly rather than doing iterative mutation. It constructs and returns the module only at the very end.

Smaller changes:
  - added documentation
  - renamed a few methods
  - never use the local variable names `exports` or `module` because those are globals with `any` type in node, so you can accidentally end up with unsafety. also there are enough kinds of "module" and "export" going on in this code that clarity is helpful IMO.
  - mark a bunch more stuff private
  - remove the `currentStatementIndex` member on `DocumentConverter`