### PR TITLE
Fix a strange issue with jscodeshift types.

### DIFF
--- a/custom_typings/jscodeshift-builders.d.ts
+++ b/custom_typings/jscodeshift-builders.d.ts
@@ -8,17 +8,17 @@
 
 declare module 'jscodeshift' {
 
+  import * as estree from 'estree';
+
   declare module jscodeshift {
-
-    import * as estree from 'estree';
-
     export function sourceLocation(start: estree.Position, end: estree.Position, source?: (string|null)): estree.SourceLocation;
 
     export function position(line: number, column: number): estree.Position;
 
     export function file(program: estree.Program, name?: (string|null)): estree.File;
 
-    export function program(body: estree.Statement[]): estree.Program;
+    // TODO(rictic): teach gen-ts-types to get this type union right.
+    export function program(body: Array<estree.Statement|estree.ModuleDeclaration>): estree.Program;
 
     export function identifier(name: string): estree.Identifier;
 

--- a/src/tools/gen-ts-types.ts
+++ b/src/tools/gen-ts-types.ts
@@ -98,10 +98,9 @@ const declaration = `
 // that exports jscodeshift
 
 declare module 'jscodeshift' {
+  import * as estree from 'estree';
 
   declare module jscodeshift {
-
-    import * as estree from 'estree';
 
     ${builders.join('\n    ')}
   }


### PR DESCRIPTION
It looks like at some point typescript got confused by what we're doing here. It couldn't figure out the `estree` types inside jscodeshift-builders.d.ts so it was silently turning them all until `any`.

Moving the import up one level seems to fix it.

Also manually fixed up the type of `jscodeshift.program()`.