### PR TITLE
ignore out directory when converting

### DIFF
--- a/fixtures/already-converted-package/foobar.html
+++ b/fixtures/already-converted-package/foobar.html
@@ -1,0 +1,7 @@
+<script>
+  (function() {
+    'use strict';
+
+    const foo = 'bar';
+  })();
+</script>

--- a/fixtures/already-converted-package/html2js_out/foobar.js
+++ b/fixtures/already-converted-package/html2js_out/foobar.js
@@ -1,0 +1,1 @@
+const foo = 'bar';

--- a/src/analysis-converter.ts
+++ b/src/analysis-converter.ts
@@ -42,7 +42,7 @@ export interface AnalysisConverterOptions {
    * Files to exclude from conversion (ie lib/utils/boot.html). Imports
    * to these files are also excluded.
    */
-  readonly excludes?: Iterable<string>;
+  readonly excludes?: string[];
 
   /**
    * Namespace references (ie, Polymer.DomModule) to "exclude"" be replacing
@@ -127,12 +127,14 @@ export class AnalysisConverter {
   }
 
   async convert(): Promise<Map<string, string>> {
+    const excludesArray = Array.from(this._excludes);
+    const isNotExcluded = (d: Document) => {
+      return !excludesArray.some(d.url.startsWith.bind(d.url));
+    };
     const htmlDocuments =
         [...this._analysis.getFeatures({kind: 'html-document'})]
-            // Excludes
-            .filter((d) => {
-              return !this._excludes.has(d.url) && isNotExternal(d) && d.url;
-            });
+            // Exclude Documents
+            .filter((d) => isNotExternal(d) && isNotExcluded(d));
 
     const results = new Map<string, string>();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,7 +163,7 @@ export async function run() {
   }
 
   await convertPackage({
-    inDir: options.in,
+    inDir: options.in || process.cwd(),
     outDir: options.out,
     excludes: options.exclude,
     namespaces: options.namespace,

--- a/src/tools/test-polymer.ts
+++ b/src/tools/test-polymer.ts
@@ -60,6 +60,7 @@ function rework(line: string) {
   }
 
   const options = {
+    outDir: 'html2js_out',
     inDir: sourceDir,
     packageName: '@polymer/polymer',
     packageVersion: '3.0.0',


### PR DESCRIPTION
Currently, all sub-directories, including `html2js_out`, are converted. This creates a new level in a potentially-infinitely deep tree of `html2js_out/html2js_out/html2js_out/html2js_out/html2js_out/...` each time the converter is run. This slows analysis & conversion each time.

- `outDir` is now always excluded from conversion
- `outDir` & `inDir` are now required options. Defaults are now set/handled a level above in the CLI layer.
- New test
- A little test cleanup