### PR TITLE
Pin github dep to ~9.2 because of typings issue in 9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "command-line-usage": "^4.0.0",
     "esprima": "^3.1.3",
     "estraverse": "^4.2.0",
-    "github": "^9.2.0",
+    "github": "~9.2.0",
     "inquirer": "^3.2.0",
     "ix": "^2.0.1",
     "jscodeshift": "^0.3.30",


### PR DESCRIPTION
This makes npm install work.