### PR TITLE
tslib is a peer dependency of ix, so adding to dependencies, since ix is used in code (not just in dev/test)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "resolve": "^1.3.3",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
-    "source-map-support": "^0.4.15"
+    "source-map-support": "^0.4.15",
+    "tslib": "^1.7.1"
   },
   "devDependencies": {
     "chalk": "^2.0.1",


### PR DESCRIPTION
Need this in here because otherwise running 'modulizer' from npm install of published package will throw:
```
Error: Cannot find module 'tslib'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/brendanb/.nvm/versions/node/v8.4.0/lib/node_modules/polymer-modulizer/node_modules/ix/targets/es5/cjs/iterable/defer.js:2:15)
```