### PR TITLE
Fix error thrown when unlinking an non-existing file

### DIFF
--- a/src/convert-package.ts
+++ b/src/convert-package.ts
@@ -122,7 +122,7 @@ export async function convertPackage(options: ConvertPackageOptions) {
     mkdirp.sync(path.dirname(outPath));
     if (newSource !== undefined) {
       await fs.writeFile(outPath, newSource);
-    } else {
+    } else if (fs.existsSync(outPath)) {
       await fs.unlink(outPath);
     }
   }


### PR DESCRIPTION
I hit the same error when trying to modulize the Polymer core library. It seems that the source is not generated, but the file was not generated as well. Therefore add a safe-guard that if the file actually exists we remove the file.

I did not remove the else-clause as I was uncertain in what case it was actually used, thus a safe-guard seemed a safer approach.

Fixes #179