### PR TITLE
Add ability to push to github & npm after modulization is complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mkdirp": "^0.5.1",
     "mz": "^2.6.0",
     "polymer-analyzer": "^2.0.2",
-    "polymer-workspaces": "^1.0.0",
+    "polymer-workspaces": "^1.1.0",
     "recast": "^0.12.4",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,6 +111,20 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
         `If given, may overwrite or delete files when converting the given ` +
         `input directory.`,
   },
+  {
+    name: 'push',
+    type: Boolean,
+    defaultValue: false,
+    description:
+        `If given, run prompts after conversion to push repo changes to github.`,
+  },
+  {
+    name: 'publish',
+    type: Boolean,
+    defaultValue: false,
+    description:
+        `If given, run prompts after conversion to publish package changes to npm.`,
+  },
 ];
 
 export interface CliOptions {
@@ -128,6 +142,8 @@ export interface CliOptions {
   'workspace-dir'?: string;
   'github-token'?: string;
   force: boolean;
+  push: boolean;
+  publish: boolean;
 }
 
 export async function run() {

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -20,6 +20,9 @@ import {Workspace} from 'polymer-workspaces';
 import {CliOptions} from '../cli';
 import {convertWorkspace} from '../convert-workspace';
 
+import workspacePublish from './workspace-publish';
+import workspacePush from './workspace-push';
+
 const githubTokenMessage = `
 You need to create a github token and place it in a file named 'github-token'.
 The token does not need any permissions.
@@ -97,4 +100,15 @@ export default async function run(options: CliOptions) {
 
   console.log(
       chalk.dim('[3/3]') + ' 🎉  ' + chalk.magenta(`Conversion Complete!`));
+
+  if (options.push) {
+    await workspacePush(workspace, reposToConvert);
+  }
+  if (options.publish) {
+    await workspacePublish(workspace, reposToConvert);
+  }
+  if (!options.push && !options.publish) {
+    console.log(
+        `When you're ready, run with --push/--publish to push changes to github and/or npm.`);
+  }
 }

--- a/src/cli/workspace-publish.ts
+++ b/src/cli/workspace-publish.ts
@@ -24,14 +24,14 @@ export default async function run(
 
   const whoAmI = await reposToConvert[0].npm.whoami();
   console.log(`npm whoami: ${whoAmI}`);
-  const {publishTag} = (await inquirer.prompt([
+  const {publishTag} = await inquirer.prompt([
     {
       type: 'input',
       name: 'publishTag',
       message: 'publish to npm tag:',
       default: 'latest',
     },
-  ]));
+  ]);
 
   console.log('');
   console.log('Ready to publish:');

--- a/src/cli/workspace-publish.ts
+++ b/src/cli/workspace-publish.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as chalk from 'chalk';
+import * as inquirer from 'inquirer';
+import {Workspace, WorkspaceRepo} from 'polymer-workspaces';
+
+export default async function run(
+    workspace: Workspace, reposToConvert: WorkspaceRepo[]) {
+
+  console.log(
+      chalk.dim('[1/3] ') + chalk.magenta(`Setting up publish to npm...`));
+
+  const whoAmI = await reposToConvert[0].npm.whoami();
+  console.log(`npm whoami: ${whoAmI}`);
+  const {publishTag} = (await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'publishTag',
+      message: 'publish to npm tag:',
+      default: 'latest',
+    },
+  ]));
+
+  console.log('');
+  console.log('Ready to publish:');
+  for (const repo of reposToConvert) {
+    const packageInfo = await repo.npm.getPackageManifest();
+    console.log(`  - ${chalk.cyan(publishTag)}: ${packageInfo.name}${
+        chalk.dim('@')}${packageInfo.version}`);
+  }
+  console.log('');
+
+  const {confirmPublish} = (await inquirer.prompt([{
+    type: 'confirm',
+    name: 'confirmPublish',
+    message: 'start?',
+    default: true,
+  }]));
+
+  if (!confirmPublish) {
+    return;
+  }
+
+  console.log(chalk.dim('[2/3] ') + chalk.magenta(`Publishing to npm...`));
+  await workspace.publishPackagesToNpm(reposToConvert, publishTag);
+
+  console.log(chalk.dim('[3/3]') + ' 🎉  ' + chalk.magenta(`Publish Complete!`));
+}

--- a/src/cli/workspace-push.ts
+++ b/src/cli/workspace-push.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as chalk from 'chalk';
+import * as inquirer from 'inquirer';
+import {Workspace, WorkspaceRepo} from 'polymer-workspaces';
+
+export default async function run(
+  workspace: Workspace, reposToConvert: WorkspaceRepo[]) {
+
+  console.log(
+      chalk.dim('[1/5] ') + chalk.magenta(`Setting up push to GitHub...`));
+  const {commitMessage, branchName, forcePush} = (await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'branchName',
+      message: 'push to branch:',
+      default: 'polymer-modulizer-auto-generated',
+    },
+    {
+      type: 'confirm',
+      name: 'forcePush',
+      message:
+          'force push? (WARNING: This will overwrite any existing branch on github)',
+      default: false,
+    },
+    {
+      type: 'input',
+      name: 'commitMessage',
+      message: 'with commit message:',
+      default: '"auto-generated with polymer-modulizer"',
+    }
+  ]));
+
+  console.log(chalk.dim('[2/5] ') + chalk.magenta(`Preparing new branches...`));
+  await workspace.startNewBranch(reposToConvert, 'polymer-modulizer-staging');
+
+  console.log(chalk.dim('[3/5] ') + chalk.magenta(`Committing changes...`));
+  await workspace.commitChanges(reposToConvert, commitMessage);
+
+  console.log('');
+  console.log('Ready to push:');
+  for (const repo of reposToConvert) {
+    console.log(`  - ${repo.github.fullName}  ${
+        chalk.dim(repo.github.ref || repo.github.defaultBranch)} -> ${
+        chalk.cyan(branchName)}`);
+  }
+  console.log('');
+
+  const {confirmPush} = (await inquirer.prompt([{
+    type: 'confirm',
+    name: 'confirmPush',
+    message: 'start?',
+    default: true,
+  }]));
+  if (!confirmPush) {
+    return;
+  }
+
+  console.log(chalk.dim('[4/5] ') + chalk.magenta(`Pushing to GitHub...`));
+  await workspace.pushChangesToGithub(reposToConvert, branchName, forcePush);
+
+  console.log(chalk.dim('[5/5]') + ' 🎉  ' + chalk.magenta(`Push Complete!`));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,12 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.1.tgz#b683eb60be358304ef146f5775db4c0e3696a550"
 
+"@types/mkdirp@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.1.tgz#ea887cd024f691c1ca67cce20b7606b053e43b0f"
+  dependencies:
+    "@types/node" "*"
+
 "@types/mocha@^2.2.41":
   version "2.2.43"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.43.tgz#03c54589c43ad048cbcbfd63999b55d0424eec27"
@@ -3100,9 +3106,9 @@ polymer-analyzer@^2.0.2:
     shady-css-parser "0.0.8"
     strip-indent "^2.0.0"
 
-polymer-workspaces@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/polymer-workspaces/-/polymer-workspaces-1.0.2.tgz#fd5463953a88bb2ac0b1547610d3cd2882ead03a"
+polymer-workspaces@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/polymer-workspaces/-/polymer-workspaces-1.1.0.tgz#e049fe07ba338dc0188591160f5615fa78e484c2"
   dependencies:
     "@types/rimraf" "^2.0.2"
     github "^11.0.0"


### PR DESCRIPTION
This completes the "workspaces" flow for pushing & publishing changes to multiple repos after conversion. This previously had to be done by hand using some janky scripts & bash magic.

[demo!](https://gfycat.com/gifs/detail/MagnificentFreshHartebeest)

Travis won't pass until the two workspaces dependencies are pushed and published:
- [X] https://github.com/Polymer/polymer-workspaces/pull/7
- [X] https://github.com/Polymer/polymer-workspaces/pull/8
- [X] https://github.com/Polymer/polymer-workspaces/pull/10 (important bug fix)