### PR TITLE
Refactor the CLI logic interface to support both package layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ add the new ones in the current directory:
 
 ```sh
 bower cache clean && bower install
-modulizer --out .
+modulizer package --out .
 ```
 
 ### Workspace mode
@@ -91,7 +91,7 @@ You must first generate a GitHub access token and store it in a file named `gith
 Then run:
 
 ```sh
-modulizer owner/repo owner2/repo2
+modulizer workspace --repo owner/repo owner2/repo2
 ```
 
 This will create a `modulizer_workspace` directory and checkout the repos and their Bower dependencies and convert them all in place. You can then run `polymer serve` in the workspace directory and try out the results in Chrome 61 or Safari 10.1 (or Edge and Firefox with the appropriate flags turned on).

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as commandLineArgs from 'command-line-args';
+import {NpmImportStyle} from '../conversion-settings';
+
+/**
+ * Definitions for all supported CLI arguments, in the OptionDefinition[] format
+ * specified by the "commandLineArgs" library.
+ */
+export const commandLineArgDefinitions: commandLineArgs.OptionDefinition[] = [
+  {
+    name: 'mode',
+    type: String,
+    description: `The mode modulizer mode to run. Available options are: ` +
+        `"package", "workspace".`,
+    defaultOption: true
+  },
+  {
+    name: 'repo',
+    alias: 'r',
+    type: String,
+    multiple: true,
+    description: 'Repositories to convert.',
+  },
+  {
+    name: 'workspace-dir',
+    alias: 'd',
+    type: String,
+    defaultValue: 'modulizer_workspace',
+    description:
+        'Override the default path "modulizer_workspace" where the repositories ' +
+        'will be cloned to.'
+  },
+  {
+    name: 'github-token',
+    alias: 'g',
+    type: String,
+    description: 'Provide github token via command-line flag instead of ' +
+        '"github-token" file.'
+  },
+  {
+    name: 'help',
+    type: Boolean,
+    description: 'Show this help message.',
+  },
+  {
+    name: 'version',
+    type: Boolean,
+    description: 'Display the version number and exit',
+  },
+  {
+    name: 'out',
+    type: String,
+    defaultValue: 'modulizer_out',
+    description: 'The directory to write converted files to.'
+  },
+  {name: 'in', type: String, description: 'The directory to convert.'},
+  {
+    name: 'namespace',
+    type: String,
+    description: 'Namespace name(s) to use to detect exports. ' +
+        'Namespaces documented in the code with @namespace will be ' +
+        'automatically detected.',
+    multiple: true
+  },
+  {
+    name: 'exclude',
+    type: String,
+    multiple: true,
+    description: 'File(s) to exclude from conversion.',
+    defaultValue: []
+  },
+  {
+    name: 'include',
+    type: String,
+    multiple: true,
+    description:
+        'Root file(s) to include in the conversion. Automatically includes' +
+        ' files listed in the bower.json main field, and any file that ' +
+        'is HTML imported.',
+    defaultValue: []
+  },
+  {
+    name: 'npm-name',
+    type: String,
+    description: 'npm package name to use for package.json'
+  },
+  {
+    name: 'npm-version',
+    type: String,
+    description: 'Version string to use for package.json'
+  },
+  {
+    name: 'clean',
+    type: Boolean,
+    defaultValue: false,
+    description: 'If given, clear the existing build/workspace folder ' +
+        +'before beginning.'
+  },
+  {
+    name: 'force',
+    type: Boolean,
+    defaultValue: false,
+    description:
+        `If given, may overwrite or delete files when converting the given ` +
+        `input directory.`,
+  },
+  {
+    name: 'import-style',
+    type: String,
+    defaultValue: 'path',
+    description:
+        `[name|path] The desired format for npm package import URLs/specifiers. ` +
+        `Defaults to "path".`,
+  },
+];
+
+/**
+ * Our internal CLI options format, parsed from the provided command line
+ * arguments.
+ */
+export interface CliOptions {
+  mode: string;
+  repo?: string[];
+  help?: boolean;
+  version?: boolean;
+  out: string;
+  in ?: string;
+  namespace?: string[];
+  exclude: string[];
+  include: string[];
+  'npm-name'?: string;
+  'npm-version'?: string;
+  clean: boolean;
+  'workspace-dir': string;
+  'github-token'?: string;
+  force: boolean;
+  'import-style': NpmImportStyle;
+}
+
+/**
+ * Parse the current command line arguments, validating that they match our
+ * arguments schema and applying defaults. Returns a single formatted object
+ * of all provided arguments.
+ */
+export function parseCommandLineArguments(): CliOptions {
+  return commandLineArgs(commandLineArgDefinitions) as CliOptions;
+}

--- a/src/cli/command-help.ts
+++ b/src/cli/command-help.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {CliOptions, commandLineArgDefinitions} from './args';
+
+
+export default async function run(_options: CliOptions) {
+  const getUsage = require('command-line-usage');
+  const usage = getUsage([
+    {
+      header: 'modulizer',
+      content: `Convert HTML Imports to JavaScript modules
+
+If no GitHub repository names are given, modulizer converts the current
+directory as a package. If repositories are provided, they are cloned into a
+workspace directory as sibling folders as they would be in a Bower
+installation.
+`,
+    },
+    {
+      header: 'Options',
+      optionList: commandLineArgDefinitions,
+    }
+  ]);
+  console.log(usage);
+}

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -16,10 +16,10 @@ import * as inquirer from 'inquirer';
 import * as path from 'path';
 import * as semver from 'semver';
 
-import {CliOptions} from '../cli';
 import convertPackage from '../convert-package';
 import {readJson} from '../manifest-converter';
 import {exec} from '../util';
+import {CliOptions} from './args';
 
 export default async function run(options: CliOptions) {
   const inDir = path.resolve(options.in || process.cwd());

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -17,8 +17,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {Workspace} from 'polymer-workspaces';
 
-import {CliOptions} from '../cli';
 import convertWorkspace from '../convert-workspace';
+import {CliOptions} from './args';
 
 const githubTokenMessage = `
 You need to create a github token and place it in a file named 'github-token'.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,166 +12,21 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as commandLineArgs from 'command-line-args';
-import {NpmImportStyle} from '../conversion-settings';
 
+import {CliOptions, parseCommandLineArguments} from './args';
+import runHelpCommand from './command-help';
 import runPackageCommand from './command-package';
 import runWorkspaceCommand from './command-workspace';
 
-const optionDefinitions: commandLineArgs.OptionDefinition[] = [
-  {
-    name: 'repo',
-    alias: 'r',
-    type: String,
-    multiple: true,
-    description:
-        'Repositories to convert.  (This is the default option, so the ' +
-        '--repo/-r switch itself is not required.)',
-    defaultOption: true
-  },
-  {
-    name: 'workspace-dir',
-    alias: 'd',
-    type: String,
-    defaultValue: 'modulizer_workspace',
-    description:
-        'Override the default path "modulizer_workspace" where the repositories ' +
-        'will be cloned to.'
-  },
-  {
-    name: 'github-token',
-    alias: 'g',
-    type: String,
-    description: 'Provide github token via command-line flag instead of ' +
-        '"github-token" file.'
-  },
-  {
-    name: 'help',
-    type: Boolean,
-    description: 'Show this help message.',
-  },
-  {
-    name: 'version',
-    type: Boolean,
-    description: 'Display the version number and exit',
-  },
-  {
-    name: 'out',
-    type: String,
-    defaultValue: 'modulizer_out',
-    description: 'The directory to write converted files to.'
-  },
-  {name: 'in', type: String, description: 'The directory to convert.'},
-  {
-    name: 'namespace',
-    type: String,
-    description: 'Namespace name(s) to use to detect exports. ' +
-        'Namespaces documented in the code with @namespace will be ' +
-        'automatically detected.',
-    multiple: true
-  },
-  {
-    name: 'exclude',
-    type: String,
-    multiple: true,
-    description: 'File(s) to exclude from conversion.',
-    defaultValue: []
-  },
-  {
-    name: 'include',
-    type: String,
-    multiple: true,
-    description:
-        'Root file(s) to include in the conversion. Automatically includes' +
-        ' files listed in the bower.json main field, and any file that ' +
-        'is HTML imported.',
-    defaultValue: []
-  },
-  {
-    name: 'npm-name',
-    type: String,
-    description: 'npm package name to use for package.json'
-  },
-  {
-    name: 'npm-version',
-    type: String,
-    description: 'Version string to use for package.json'
-  },
-  {
-    name: 'clean',
-    type: Boolean,
-    defaultValue: false,
-    description: 'If given, clear the existing build/workspace folder ' +
-        +'before beginning.'
-  },
-  {
-    name: 'force',
-    type: Boolean,
-    defaultValue: false,
-    description:
-        `If given, may overwrite or delete files when converting the given ` +
-        `input directory.`,
-  },
-  {
-    name: 'import-style',
-    type: String,
-    defaultValue: 'path',
-    description:
-        `[name|path] The desired format for npm package import URLs/specifiers. ` +
-        `Defaults to "path".`,
-  },
-];
-
-export interface CliOptions {
-  repo?: string[];
-  help?: boolean;
-  version?: boolean;
-  out: string;
-  'in'?: string;
-  namespace?: string[];
-  exclude: string[];
-  include: string[];
-  'npm-name'?: string;
-  'npm-version'?: string;
-  clean: boolean;
-  'workspace-dir': string;
-  'github-token'?: string;
-  force: boolean;
-  'import-style': NpmImportStyle;
-}
-
 export async function run() {
-  const options: CliOptions = commandLineArgs(optionDefinitions) as any;
+  const options: CliOptions = parseCommandLineArguments();
 
   if (options['help']) {
-    const getUsage = require('command-line-usage');
-    const usage = getUsage([
-      {
-        header: 'modulizer',
-        content: `Convert HTML Imports to JavaScript modules
-
-If no GitHub repository names are given, modulizer converts the current
-directory as a package. If repositories are provided, they are cloned into a
-workspace directory as sibling folders as they would be in a Bower
-installation.
-`,
-      },
-      {
-        header: 'Options',
-        optionList: optionDefinitions,
-      }
-    ]);
-    console.log(usage);
-    return;
+    return runHelpCommand(options);
   }
 
   if (options['version']) {
     console.log(require('../package.json').version);
-    return;
-  }
-
-  if (options['repo']) {
-    await runWorkspaceCommand(options);
     return;
   }
 
@@ -182,5 +37,17 @@ installation.
         `Supported styles: "name", "path".`);
   }
 
-  await runPackageCommand(options);
+  switch (options.mode) {
+    case 'package':
+      return runPackageCommand(options);
+
+    case 'workspace':
+      return runWorkspaceCommand(options);
+
+    default:
+      console.error(`No mode provided! Run "modulizer [mode] [options...]"`);
+      console.error(`Available modes: element, workspace`);
+      console.error(`Run "modulizer help" for more info.`);
+      process.exit(1);
+  }
 }

--- a/src/document-converter.ts
+++ b/src/document-converter.ts
@@ -471,7 +471,6 @@ export class DocumentConverter {
    * Should not be called on top-level JS Modules.
    */
   private rewriteInlineScript(program: Program) {
-
     // Any code that sets the global settings object cannot be inlined (and
     // deferred) because the settings object must be created/configured
     // before other imports evaluate in following module scripts.


### PR DESCRIPTION
***11/17: Updated for a post-layout-refactoring world! ™***

The CLI currently runs both single-package & multi-package (workspace) through the same CLI interface, with different options triggering both. `modulizer` will normally run in single-package mode, but the `--repo` turns on the completely different workspace workflow. `--repo` acts less like an option, and more like a command.

This PR refactors the CLI arguments logic with the addition of a new explicit conversion "mode". Instead of configuring package vs. workspace through some combination of flags, the user now sets the mode explicitly via a command:

```
$ modulizer package --out . --force
$ modulizer workspace --repo PolymerElements/paper-*#2.0-preview --clean
```
