### PR TITLE
[ProjectConverter] Clean up CLI setup/layout

### DIFF
--- a/bin/modulizer.js
+++ b/bin/modulizer.js
@@ -20,7 +20,7 @@ process.title = 'modulizer';
 
 require('source-map-support').install();
 
-const {run} = require('../lib/cli');
+const {run} = require('../lib/cli/index');
 
 process.on('unhandledRejection', (reason, p) => {
   console.log('Unhandled Rejection at: Promise ', p, ' reason: ', reason);

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -11,13 +11,13 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-
 import * as chalk from 'chalk';
 import * as inquirer from 'inquirer';
+import * as path from 'path';
 import * as semver from 'semver';
 
 import {CliOptions} from '../cli';
-import {convertPackage} from '../convert-package';
+import convertPackage from '../convert-package';
 import {readJson} from '../manifest-converter';
 
 export default async function run(options: CliOptions) {
@@ -36,20 +36,22 @@ export default async function run(options: CliOptions) {
   let inBowerJson: {name: string, version: string, main: any}|undefined;
   let inPackageJson: {name: string, version: string}|undefined;
   let outPackageJson: {name: string, version: string}|undefined;
+  const inDir = path.resolve(options.in || process.cwd());
+  const outDir = path.resolve(options.out);
   try {
-    outPackageJson = readJson(options.out, 'package.json');
+    outPackageJson = readJson(outDir, 'package.json');
   } catch (e) {
     // do nothing
   }
   try {
     if (options.in) {
-      inPackageJson = readJson(options.in, 'package.json');
+      inPackageJson = readJson(inDir, 'package.json');
     }
   } catch (e) {
     // do nothing
   }
   try {
-    inBowerJson = readJson('bower.json');
+    inBowerJson = readJson(inDir, 'bower.json');
   } catch (e) {
     // do nothing
   }
@@ -95,14 +97,14 @@ export default async function run(options: CliOptions) {
       chalk.dim('[1/2]') + ' 🌀  ' + chalk.magenta(`Converting Package...`));
 
   await convertPackage({
-    inDir: options.in,
-    outDir: options.out,
+    inDir: inDir,
+    outDir: outDir,
     excludes: options.exclude,
     namespaces: options.namespace,
     packageName: npmPackageName.toLowerCase(),
     packageVersion: npmPackageVersion,
-    cleanOutDir: options.clean,
-    mainFiles
+    cleanOutDir: options.clean!!,
+    mainFiles,
   });
 
   console.log(

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 import {Workspace} from 'polymer-workspaces';
 
 import {CliOptions} from '../cli';
-import {convertWorkspace} from '../convert-workspace';
+import convertWorkspace from '../convert-workspace';
 
 const githubTokenMessage = `
 You need to create a github token and place it in a file named 'github-token'.
@@ -55,7 +55,7 @@ function loadGitHubToken(): string|null {
 
 
 export default async function run(options: CliOptions) {
-  const workspaceDir = options['workspace-dir'];
+  const workspaceDir = path.resolve(options['workspace-dir']);
   console.log(
       chalk.dim('[1/3]') + ' 🚧  ' +
       chalk.magenta(`Setting Up Workspace "${workspaceDir}"...`));
@@ -73,7 +73,7 @@ export default async function run(options: CliOptions) {
 
   const workspace = new Workspace({
     token: githubToken,
-    dir: path.resolve(workspaceDir),
+    dir: workspaceDir,
   });
 
   const reposToConvert = await workspace.init(
@@ -91,7 +91,8 @@ export default async function run(options: CliOptions) {
       chalk.magenta(`Converting ${reposToConvert.length} Package(s)...`));
 
   await convertWorkspace({
-    inDir: options['workspace-dir']!,
+    workspaceDir,
+    reposToConvert,
     packageVersion: npmPackageVersion,
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,8 +14,8 @@
 
 import * as commandLineArgs from 'command-line-args';
 
-import runPackageCommand from './cli/command-package';
-import runWorkspaceCommand from './cli/command-workspace';
+import runPackageCommand from './command-package';
+import runWorkspaceCommand from './command-workspace';
 
 const optionDefinitions: commandLineArgs.OptionDefinition[] = [
   {
@@ -125,7 +125,7 @@ export interface CliOptions {
   'npm-name'?: string;
   'npm-version'?: string;
   clean: boolean;
-  'workspace-dir'?: string;
+  'workspace-dir': string;
   'github-token'?: string;
   force: boolean;
 }

--- a/src/convert-workspace.ts
+++ b/src/convert-workspace.ts
@@ -15,29 +15,67 @@
 import {fs} from 'mz';
 import * as path from 'path';
 import {Analysis, Analyzer, FSUrlLoader, InMemoryOverlayUrlLoader, PackageUrlResolver} from 'polymer-analyzer';
+import {WorkspaceRepo} from 'polymer-workspaces';
 
 import {BaseConverterOptions} from './base-converter';
 import {dependencyMap, generatePackageJson, readJson, writeJson} from './manifest-converter';
 import {polymerFileOverrides} from './special-casing';
 import {WorkspaceConverter} from './workspace-converter';
 
-import mkdirpCallback = require('mkdirp');
+import util = require('util');
+import _mkdirp = require('mkdirp');
+const mkdirp = util.promisify(_mkdirp);
 
-
-const mkdirp = (dir: string) =>
-    new Promise((resolve, reject) => mkdirpCallback(dir, (e, made) => {
-                  return e == null ? resolve(made) : reject(e);
-                }));
 
 interface ConvertWorkspaceOptions extends BaseConverterOptions {
   packageVersion: string;
-  inDir: string;
+  workspaceDir: string;
+  reposToConvert: WorkspaceRepo[];
+}
+
+/**
+ * Create a symlink from the repo into the workspace's node_modules directory.
+ */
+async function writeNpmSymlink(
+    options: ConvertWorkspaceOptions, repo: WorkspaceRepo) {
+  const packageJsonPath = path.join(repo.dir, 'package.json');
+  if (!await fs.exists(packageJsonPath)) {
+    return;
+  }
+  const packageJson = readJson(packageJsonPath);
+  let packageName = packageJson['name'] as string;
+  let parentName = path.join(options.workspaceDir, 'node_modules');
+  if (packageName.startsWith('@')) {
+    const slashIndex = packageName.indexOf('/');
+    const scopeName = packageName.substring(0, slashIndex);
+    parentName = path.join(parentName, scopeName);
+    packageName = packageName.substring(slashIndex + 1);
+  }
+  await mkdirp(parentName);
+  const linkName = path.join(parentName, packageName);
+  await fs.symlink(repo.dir, path.resolve(linkName));
+}
+
+/**
+ * For a given repo, generate a new package.json and write it to disk.
+ */
+async function writePackageJson(repo: WorkspaceRepo, packageVersion: string) {
+  const bowerJsonPath = path.join(repo.dir, 'bower.json');
+  const bowerJson = readJson(bowerJsonPath);
+  const bowerName = bowerJson.name;
+  let depMapping: {npm: string}|undefined = dependencyMap[bowerName];
+  if (!depMapping) {
+    console.warn(`"${bowerName}" npm mapping not found`);
+    depMapping = {npm: bowerName};
+  }
+  const packageJson =
+      generatePackageJson(bowerJson, depMapping.npm, packageVersion);
+  writeJson(packageJson, repo.dir, 'package.json');
 }
 
 export function configureAnalyzer(options: ConvertWorkspaceOptions) {
-  const inDir = options.inDir || process.cwd();
-
-  const urlLoader = new InMemoryOverlayUrlLoader(new FSUrlLoader(inDir));
+  const workspaceDir = options.workspaceDir;
+  const urlLoader = new InMemoryOverlayUrlLoader(new FSUrlLoader(workspaceDir));
   for (const [url, contents] of polymerFileOverrides) {
     urlLoader.urlContentsMap.set(`polymer/${url}`, contents);
   }
@@ -66,14 +104,18 @@ export function configureConverter(
   });
 }
 
-export async function convertWorkspace(options: ConvertWorkspaceOptions) {
+/**
+ * Convert a set of workspace repos to JavaScript modules & npm.
+ */
+export default async function convert(options: ConvertWorkspaceOptions) {
   const analyzer = configureAnalyzer(options);
   const analysis = await analyzer.analyzePackage();
   const converter = configureConverter(analysis, options);
   const results = await converter.convert();
 
+  // Process & write each conversion result:
   for (const [outUrl, newSource] of results) {
-    const outPath = path.join(options.inDir, outUrl);
+    const outPath = path.join(options.workspaceDir, outUrl);
     if (newSource === undefined) {
       await fs.unlink(outPath);
     } else {
@@ -81,60 +123,23 @@ export async function convertWorkspace(options: ConvertWorkspaceOptions) {
     }
   }
 
-  for (const repo of await fs.readdir(options.inDir)) {
-    await writePackageJson(options, repo);
-    await writeNpmSymlink(options, repo);
-  }
-}
-
-async function writeNpmSymlink(options: ConvertWorkspaceOptions, repo: string) {
-  const repoPath = path.join(options.inDir, repo);
-  const packageJsonPath = path.join(repoPath, 'package.json');
-  if (!await fs.exists(packageJsonPath)) {
-    return;
-  }
-  const packageJson = readJson(packageJsonPath);
-  let packageName = packageJson['name'] as string;
-  let parentName = path.join(options.inDir, 'node_modules');
-  if (packageName.startsWith('@')) {
-    const slashIndex = packageName.indexOf('/');
-    const scopeName = packageName.substring(0, slashIndex);
-    parentName = path.join(parentName, scopeName);
-    packageName = packageName.substring(slashIndex + 1);
-  }
-  try {
-    await mkdirp(parentName);
-    const linkName = path.join(parentName, packageName);
-    await fs.symlink(path.resolve(repoPath), path.resolve(linkName));
-  } catch (e) {
-    console.error(e);
-  }
-}
-
-async function writePackageJson(
-    options: ConvertWorkspaceOptions, repo: string) {
-  const bowerPath = path.join(options.inDir, repo, 'bower.json');
-  const bowerExists = await fs.exists(bowerPath);
-  if (!bowerExists) {
-    return;
-  }
-  try {
-    const bowerJson = readJson(bowerPath);
-    // TODO(https://github.com/Polymer/polymer-modulizer/issues/122):
-    // unhardcode
-    const bowerName = bowerJson.name;
-
-    let depMapping: {npm: string}|undefined = dependencyMap[bowerName];
-    if (!depMapping) {
-      console.warn(`"${bowerName}" npm mapping not found`);
-      depMapping = {npm: bowerName};
+  // For each repo, generate a new package.json:
+  for (const repo of options.reposToConvert) {
+    try {
+      writePackageJson(repo, options.packageVersion);
+    } catch (err) {
+      console.log('Error in bower.json -> package.json conversion:');
+      console.error(err);
     }
+  }
 
-    const packageJson =
-        generatePackageJson(bowerJson, depMapping.npm, options.packageVersion);
-    writeJson(packageJson, options.inDir, repo, 'package.json');
-  } catch (e) {
-    console.log('error in bower.json -> package.json conversion');
-    console.error(e);
+  // For each repo, generate a node_modules/ symlink in the workspace directory:
+  for (const repo of options.reposToConvert) {
+    try {
+      await writeNpmSymlink(options, repo);
+    } catch (err) {
+      console.log(`Error in npm symlink creation:`);
+      console.error(err);
+    }
   }
 }

--- a/src/test/analysis-converter_test.ts
+++ b/src/test/analysis-converter_test.ts
@@ -2380,6 +2380,7 @@ Polymer({
   test('case-map', async () => {
     const options = {
       inDir: fixturesDirPath,
+      outDir: fixturesDirPath,
       packageName: 'case-map',
       packageVersion: '1.0.0',
       mainFiles: ['case-map/case-map.html']
@@ -2398,6 +2399,7 @@ Polymer({
   test('polymer-element', async () => {
     const options = {
       inDir: fixturesDirPath,
+      outDir: fixturesDirPath,
       packageName: 'polymer-element',
       packageVersion: '1.0.0'
     };

--- a/src/tools/checkpoint-polymer.ts
+++ b/src/tools/checkpoint-polymer.ts
@@ -18,7 +18,7 @@ require('source-map-support').install();
 import * as path from 'path';
 import {exec} from 'mz/child_process';
 import {exists} from 'mz/fs';
-import {convertPackage} from '../convert-package';
+import convertPackage from '../convert-package';
 
 const repoUrl = 'https://github.com/Polymer/polymer.git';
 const fixturesDirPath =

--- a/src/tools/test-polymer.ts
+++ b/src/tools/test-polymer.ts
@@ -64,6 +64,7 @@ function rework(line: string) {
 
   const options = {
     inDir: sourceDir,
+    outDir: sourceDir,
     packageName: '@polymer/polymer',
     packageVersion: '3.0.0',
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,12 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.1.tgz#b683eb60be358304ef146f5775db4c0e3696a550"
 
+"@types/mkdirp@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.1.tgz#ea887cd024f691c1ca67cce20b7606b053e43b0f"
+  dependencies:
+    "@types/node" "*"
+
 "@types/mocha@^2.2.41":
   version "2.2.43"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.43.tgz#03c54589c43ad048cbcbfd63999b55d0424eec27"


### PR DESCRIPTION
*A part of #217: "Refactor ProjectConverter to Fix URL Handling"*
*Builds off of #216: "Fix outputs keying to prevent cache missing, duplicates"*

## Summary:

This PR cleans up some of the CLI logic and partially-moved file structure.

- some bug fixes around path resolution for paths provided by the CLI
- The main CLI entrypoint is moved into the `cli/` subdirectory with the other CLI logic
- inDir & outDir are now always resolved by the time they get to the `convert()` method.
- workspace conversion runs off the polymer-workspaces list of repos, instead of a directory scan

