### PR TITLE
[ProjectConverter] Clean up url-converter logic/layout

### DIFF
--- a/src/analysis-converter.ts
+++ b/src/analysis-converter.ts
@@ -17,7 +17,7 @@ import {Analysis, Document} from 'polymer-analyzer';
 import {BaseConverter, BaseConverterOptions} from './base-converter';
 import {ConversionMetadata} from './conversion-metadata';
 import {DocumentConverter} from './document-converter';
-import {OriginalDocumentUrl} from './url-converter';
+import {OriginalDocumentUrl} from './urls/types';
 
 const _isInBowerRegex = /(\b|\/|\\)(bower_components)(\/|\\)/;
 const _isInNpmRegex = /(\b|\/|\\)(node_modules)(\/|\\)/;

--- a/src/base-converter.ts
+++ b/src/base-converter.ts
@@ -19,7 +19,8 @@ import {Analysis, Document} from 'polymer-analyzer';
 
 import {DocumentConverter} from './document-converter';
 import {ConversionResult, JsExport} from './js-module';
-import {ConvertedDocumentFilePath, getDocumentUrl, OriginalDocumentUrl} from './url-converter';
+import {ConvertedDocumentFilePath, OriginalDocumentUrl} from './urls/types';
+import {getDocumentUrl} from './urls/util';
 import {getNamespaces} from './util';
 
 export interface BaseConverterOptions {

--- a/src/conversion-metadata.ts
+++ b/src/conversion-metadata.ts
@@ -16,7 +16,7 @@ import * as estree from 'estree';
 import {Document} from 'polymer-analyzer';
 
 import {ConversionResult, JsExport} from './js-module';
-import {OriginalDocumentUrl} from './url-converter';
+import {OriginalDocumentUrl} from './urls/types';
 
 export interface ConversionMetadata {
   readonly namespaces: ReadonlySet<string>;

--- a/src/document-converter.ts
+++ b/src/document-converter.ts
@@ -31,7 +31,8 @@ import {removeUnnecessaryEventListeners} from './passes/remove-unnecessary-waits
 import {removeWrappingIIFEs} from './passes/remove-wrapping-iife';
 import {rewriteNamespacesAsExports} from './passes/rewrite-namespace-exports';
 import {rewriteToplevelThis} from './passes/rewrite-toplevel-this';
-import {ConvertedDocumentFilePath, ConvertedDocumentUrl, convertHtmlDocumentUrl, convertJsDocumentUrl, getDocumentUrl, getRelativeUrl, OriginalDocumentUrl} from './url-converter';
+import {ConvertedDocumentFilePath, ConvertedDocumentUrl, OriginalDocumentUrl} from './urls/types';
+import {convertHtmlDocumentUrl, convertJsDocumentUrl, getDocumentUrl, getRelativeUrl} from './urls/util';
 import {findAvailableIdentifier, getMemberName, getMemberPath, getModuleId, getNodeGivenAnalyzerAstNode, nodeToTemplateLiteral, serializeNode} from './util';
 
 /**

--- a/src/js-module.ts
+++ b/src/js-module.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ConvertedDocumentFilePath, ConvertedDocumentUrl, OriginalDocumentUrl} from './url-converter';
+import {ConvertedDocumentFilePath, ConvertedDocumentUrl, OriginalDocumentUrl} from './urls/types';
 
 
 export interface HtmlFile {

--- a/src/test/analysis-converter_test.ts
+++ b/src/test/analysis-converter_test.ts
@@ -20,7 +20,7 @@ import {Analyzer, Document, FSUrlLoader, InMemoryOverlayUrlLoader, PackageUrlRes
 
 import {AnalysisConverter, AnalysisConverterOptions} from '../analysis-converter';
 import {configureAnalyzer, configureConverter} from '../convert-package';
-import {ConvertedDocumentFilePath} from '../url-converter';
+import {ConvertedDocumentFilePath} from '../urls/types';
 import {getMemberPath} from '../util';
 
 

--- a/src/test/urls/util_test.ts
+++ b/src/test/urls/util_test.ts
@@ -14,7 +14,8 @@
 
 import {assert} from 'chai';
 
-import {ConvertedDocumentUrl, convertHtmlDocumentUrl, getRelativeUrl, OriginalDocumentUrl} from '../url-converter';
+import {ConvertedDocumentUrl, OriginalDocumentUrl} from '../../urls/types';
+import {convertHtmlDocumentUrl, getRelativeUrl} from '../../urls/util';
 
 suite('src/url-converter', () => {
 

--- a/src/tools/test-polymer.ts
+++ b/src/tools/test-polymer.ts
@@ -19,7 +19,7 @@ import * as fs from 'mz/fs';
 import * as path from 'path';
 
 import {configureAnalyzer, configureConverter} from '../convert-package';
-import {ConvertedDocumentFilePath} from '../url-converter';
+import {ConvertedDocumentFilePath} from '../urls/types';
 
 // Install source map support for stack traces, etc.
 require('source-map-support').install();

--- a/src/urls/types.ts
+++ b/src/urls/types.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * A URL path to an document, pre-conversion. Always relative to the current
+ * project layout (package, workspace, etc).
+ */
+export type OriginalDocumentUrl = string&{_OriginalDocumentUrl: never};
+
+/**
+ * A URL path to a document, post-conversion. Uses npm naming for all URLs
+ * containing package names. Always relative to the current project layout
+ * (package, workspace, etc).
+ */
+export type ConvertedDocumentUrl = string&{_ConvertedDocumentUrl: never};
+
+/**
+ * A file path to where a document will be written, post-conversion. Unlike
+ * ConvertedDocumentUrl, this URL preserves the original package folder.
+ * Useful in workspace layouts where converted files should still be written
+ * to the original, analyzed repo.
+ */
+export type ConvertedDocumentFilePath =
+    string&{_ConvertedDocumentFilePath: never};

--- a/src/urls/types.ts
+++ b/src/urls/types.ts
@@ -13,7 +13,7 @@
  */
 
 /**
- * A URL path to an document, pre-conversion. Always relative to the current
+ * A URL path to a document, pre-conversion. Always relative to the current
  * project layout (package, workspace, etc).
  */
 export type OriginalDocumentUrl = string&{_OriginalDocumentUrl: never};

--- a/src/urls/util.ts
+++ b/src/urls/util.ts
@@ -14,32 +14,14 @@
 
 import {posix as path} from 'path';
 import {Document} from 'polymer-analyzer';
+import {dependencyMap} from '../manifest-converter';
 
-import {dependencyMap} from './manifest-converter';
+import {ConvertedDocumentUrl, OriginalDocumentUrl} from './types';
 
-const htmlExtension = '.html';
-
-/**
- * A URL path to an document, pre-conversion. Always relative to the current
- * project (package, workspace, etc).
- */
-export type OriginalDocumentUrl = string&{_OriginalDocumentUrl: never};
-
-/**
- * A URL path to a document, post-conversion. Uses npm naming for all urls
- * containing package names. Always relative to the current project (package,
- * workspace, etc).
- */
-export type ConvertedDocumentUrl = string&{_ConvertedDocumentUrl: never};
-/**
- * A file path to where a document will be written, post-conversion. Unlike
- * ConvertedDocumentUrl, this url keeps the original package folder and Bower
- * package name. Useful in workspace projects where converted files should still
- * be written to the original analyzed repo.
- */
-export type ConvertedDocumentFilePath =
-    string&{_ConvertedDocumentFilePath: never};
-
+/** The HTML file extension. */
+export const htmlExtension = '.html';
+/** The JavaScript file extension. */
+export const jsExtension = '.js';
 
 /**
  * Given an HTML url relative to the project root, return true if that url

--- a/src/urls/util.ts
+++ b/src/urls/util.ts
@@ -30,7 +30,7 @@ function isBowerDependencyUrl(htmlUrl: OriginalDocumentUrl): boolean {
 /**
  * Rewrite a url to replace a `.html` file extension with `.js`, if found.
  */
-function fixHtmlExtensionIfFound(url: string): string {
+function replaceHtmlExtensionIfFound(url: string): string {
   if (url.endsWith('.html')) {
     url = url.substring(0, url.length - '.html'.length) + '.js';
   }
@@ -43,7 +43,7 @@ function fixHtmlExtensionIfFound(url: string): string {
  */
 export function getJsModuleConvertedFilePath(originalUrl: OriginalDocumentUrl):
     ConvertedDocumentFilePath {
-  return fixHtmlExtensionIfFound(originalUrl) as ConvertedDocumentFilePath;
+  return replaceHtmlExtensionIfFound(originalUrl) as ConvertedDocumentFilePath;
 }
 
 /**
@@ -117,7 +117,7 @@ export function convertHtmlDocumentUrl(htmlUrl: OriginalDocumentUrl):
         'shadycss/entrypoints/custom-style-interface.js');
   }
   // Convert any ".html" URLs to point to their new ".js" module equivilent
-  jsUrl = fixHtmlExtensionIfFound(jsUrl);
+  jsUrl = replaceHtmlExtensionIfFound(jsUrl);
   // TODO(fks): Revisit this format? The analyzer returns URLs without this
   return ('./' + jsUrl) as ConvertedDocumentUrl;
 }

--- a/src/urls/util.ts
+++ b/src/urls/util.ts
@@ -18,11 +18,6 @@ import {dependencyMap} from '../manifest-converter';
 
 import {ConvertedDocumentUrl, OriginalDocumentUrl} from './types';
 
-/** The HTML file extension. */
-export const htmlExtension = '.html';
-/** The JavaScript file extension. */
-export const jsExtension = '.js';
-
 /**
  * Given an HTML url relative to the project root, return true if that url
  * points to a bower dependency file.
@@ -35,8 +30,11 @@ function isBowerDependencyUrl(htmlUrl: OriginalDocumentUrl): boolean {
 /**
  * Rewrite a url to replace a `.js` file extension with `.html`.
  */
-function fixHtmlExtension(htmlUrl: string): string {
-  return htmlUrl.substring(0, htmlUrl.length - htmlExtension.length) + '.js';
+function fixHtmlExtensionIfFound(htmlUrl: string): string {
+  if (!htmlUrl.endsWith('.html')) {
+    return htmlUrl;
+  }
+  return htmlUrl.substring(0, htmlUrl.length - '.html'.length) + '.js';
 }
 
 /**
@@ -103,9 +101,8 @@ export function convertHtmlDocumentUrl(htmlUrl: OriginalDocumentUrl):
   }
 
   // Convert all HTML URLs to point to JS equivilent
-  if (jsUrl.endsWith(htmlExtension)) {
-    jsUrl = fixHtmlExtension(jsUrl) as ConvertedDocumentUrl;
-  }
+  jsUrl = fixHtmlExtensionIfFound(jsUrl) as ConvertedDocumentUrl;
+
   // TODO(fks): Revisit this format? The analyzer returns URLs without this
   return ('./' + jsUrl) as ConvertedDocumentUrl;
 }

--- a/src/urls/util.ts
+++ b/src/urls/util.ts
@@ -28,16 +28,6 @@ function isBowerDependencyUrl(htmlUrl: OriginalDocumentUrl): boolean {
 }
 
 /**
- * Rewrite a url to replace a `.js` file extension with `.html`.
- */
-function fixHtmlExtensionIfFound(htmlUrl: string): string {
-  if (!htmlUrl.endsWith('.html')) {
-    return htmlUrl;
-  }
-  return htmlUrl.substring(0, htmlUrl.length - '.html'.length) + '.js';
-}
-
-/**
  * Update a bower package name in a url (at path index) to its matching npm
  * package name.
  */
@@ -79,30 +69,27 @@ export function convertHtmlDocumentUrl(htmlUrl: OriginalDocumentUrl):
         `from the analyzer, but got "${htmlUrl}"`);
   }
   // Start the creation of your converted URL, based on on the original URL
-  let jsUrl = (<ConvertedDocumentUrl>(<string>htmlUrl));
-  // If url points to a bower_components dependency, update it to point to
-  // its equivilent node_modules npm dependency.
+  let jsUrl: string = htmlUrl;
+  // If url points to a bower_components/ dependency, update it to point to
+  // its equivilent node_modules/ npm dependency.
   if (isBowerDependencyUrl(htmlUrl)) {
     jsUrl = convertBowerDependencyUrl(htmlUrl);
   }
-
   // Temporary workaround for imports of some shadycss files that wrapped
   // ES6 modules.
   if (jsUrl.endsWith('shadycss/apply-shim.html')) {
     jsUrl = jsUrl.replace(
-                'shadycss/apply-shim.html',
-                'shadycss/entrypoints/apply-shim.js') as ConvertedDocumentUrl;
+        'shadycss/apply-shim.html', 'shadycss/entrypoints/apply-shim.js');
   }
   if (jsUrl.endsWith('shadycss/custom-style-interface.html')) {
     jsUrl = jsUrl.replace(
-                'shadycss/custom-style-interface.html',
-                'shadycss/entrypoints/custom-style-interface.js') as
-        ConvertedDocumentUrl;
+        'shadycss/custom-style-interface.html',
+        'shadycss/entrypoints/custom-style-interface.js');
   }
-
-  // Convert all HTML URLs to point to JS equivilent
-  jsUrl = fixHtmlExtensionIfFound(jsUrl) as ConvertedDocumentUrl;
-
+  // Convert any ".html" URLs to point to their new ".js" module equivilent
+  if (jsUrl.endsWith('.html')) {
+    jsUrl = (jsUrl.substring(0, jsUrl.length - '.html'.length) + '.js');
+  }
   // TODO(fks): Revisit this format? The analyzer returns URLs without this
   return ('./' + jsUrl) as ConvertedDocumentUrl;
 }

--- a/src/workspace-converter.ts
+++ b/src/workspace-converter.ts
@@ -17,7 +17,7 @@ import {Document} from 'polymer-analyzer';
 import {BaseConverter} from './base-converter';
 import {ConversionMetadata} from './conversion-metadata';
 import {DocumentConverter} from './document-converter';
-import {OriginalDocumentUrl} from './url-converter';
+import {OriginalDocumentUrl} from './urls/types';
 
 /**
  * Converts an entire workspace object.


### PR DESCRIPTION
*A part of #217: "Refactor ProjectConverter to Fix URL Handling"*
*Builds off of #219: "[ProjectConverter] Clean up CLI setup/layout"*

## Summary:

This PR sets up the larger refactoring work of #217 by cleaning up some of the URL handling logic.

- No behavior changes 
- Temporarily move url-converter logic into `urls/util.ts`, in preparation for final move to UrlHandlers
- Break out types into separate `urls/types.ts` file, in preparation for additional url-related types