### PR TITLE
Add option to import npm packages by name

### DIFF
--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -94,6 +94,7 @@ export default async function run(options: CliOptions) {
     outDir: outDir,
     excludes: options.exclude,
     namespaces: options.namespace,
+    npmImportStyle: options['import-style'],
     packageName: npmPackageName.toLowerCase(),
     packageVersion: npmPackageVersion,
     cleanOutDir: options.clean!!,

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -92,8 +92,9 @@ export default async function run(options: CliOptions) {
 
   await convertWorkspace({
     workspaceDir,
-    reposToConvert,
+    npmImportStyle: options['import-style'],
     packageVersion: npmPackageVersion,
+    reposToConvert,
   });
 
   console.log(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -118,7 +118,7 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
   },
   {
     name: 'import-style',
-    type: Boolean,
+    type: String,
     defaultValue: 'path',
     description:
         `[name|path] The desired format for npm package import URLs/specifiers. ` +

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@
  */
 
 import * as commandLineArgs from 'command-line-args';
+import {NpmImportStyle} from '../conversion-settings';
 
 import runPackageCommand from './command-package';
 import runWorkspaceCommand from './command-workspace';
@@ -115,6 +116,14 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
         `If given, may overwrite or delete files when converting the given ` +
         `input directory.`,
   },
+  {
+    name: 'import-style',
+    type: Boolean,
+    defaultValue: 'path',
+    description:
+        `[name|path] The desired format for npm package import URLs/specifiers. ` +
+        `Defaults to "path".`,
+  },
 ];
 
 export interface CliOptions {
@@ -132,6 +141,7 @@ export interface CliOptions {
   'workspace-dir': string;
   'github-token'?: string;
   force: boolean;
+  'import-style': NpmImportStyle;
 }
 
 export async function run() {
@@ -167,6 +177,13 @@ installation.
   if (options['repo']) {
     await runWorkspaceCommand(options);
     return;
+  }
+
+  const importStyle = options['import-style'];
+  if (importStyle !== 'name' && importStyle !== 'path') {
+    throw new Error(
+        `import-style "${importStyle}" not supported. ` +
+        `Supported styles: "name", "path".`);
   }
 
   await runPackageCommand(options);

--- a/src/conversion-settings.ts
+++ b/src/conversion-settings.ts
@@ -27,14 +27,17 @@ export type NpmImportStyle = 'name'|'path';
  * and how each file should be formatted for conversion.
  */
 export interface ConversionSettings {
+
   /**
    * Namespace names used to detect exports.
    */
   readonly namespaces: Set<string>;
+
   /**
    * Files to exclude from conversion (ie lib/utils/boot.html).
    */
   readonly excludes: Set<string>;
+
   /**
    * Files to include in JS conversion. By default this is all local files that
    * are imported anywhere inside the package. It is up to the conversion setup
@@ -57,6 +60,7 @@ export interface ConversionSettings {
    * "marked for JS conversion" vs. "marked for HTML in-place conversion".
    */
   readonly includes: Set<string>;
+
   /**
    * Namespace references (ie, Polymer.DomModule) to "exclude" in the conversion
    * by replacing the entire reference with `undefined`. This assumes that those
@@ -66,6 +70,7 @@ export interface ConversionSettings {
    * ex: `if(Polymer.DomModule) {...` -> `if (undefined) {...`
    */
   readonly referenceExcludes: Set<string>;
+
   /**
    * Namespace references (ie, document.currentScript.ownerDocument) to
    * "rewrite" be replacing the entire reference with the given Node.
@@ -73,6 +78,7 @@ export interface ConversionSettings {
    * ex: `document.currentScript.ownerDocument` -> `window.document`
    */
   readonly referenceRewrites: Map<string, estree.Node>;
+
   /**
    * The style of imports to use in conversion:
    *
@@ -90,16 +96,19 @@ export interface ConversionSettings {
  * added.
  */
 export interface PartialConversionSettings {
+
   /**
    * Namespace names used to detect exports. Namespaces declared in the
    * code with an `@namespace` declaration are automatically detected.
    */
   readonly namespaces?: Iterable<string>;
+
   /**
    * Files to exclude from conversion (ie `lib/utils/boot.html`). Imports
    * to these files are also excluded.
    */
   readonly excludes?: Iterable<string>;
+
   /**
    * Namespace references (ie, `Polymer.DomModule`) to exclude be replacing
    * the entire reference with `undefined`.
@@ -110,6 +119,7 @@ export interface PartialConversionSettings {
    * fail the guard.
    */
   readonly referenceExcludes?: Iterable<string>;
+
   /**
    * The style of imports to use in conversion:
    *

--- a/src/conversion-settings.ts
+++ b/src/conversion-settings.ts
@@ -19,6 +19,8 @@ import {Analysis} from 'polymer-analyzer';
 
 import {getNamespaces} from './util';
 
+export type NpmImportStyle = 'name'|'path';
+
 /**
  * These are the settings used to configure the conversion. It contains
  * important information about what should be analyzed, what should be ignored,
@@ -71,6 +73,15 @@ export interface ConversionSettings {
    * ex: `document.currentScript.ownerDocument` -> `window.document`
    */
   readonly referenceRewrites: Map<string, estree.Node>;
+  /**
+   * The style of imports to use in conversion:
+   *
+   * - "name": import by npm package name
+   *   (example) '@polymer/polymer/polymer-element.js'
+   * - "path": import by relative path
+   *   (example) '../../../@polymer/polymer/polymer-element.js'
+   */
+  readonly npmImportStyle: NpmImportStyle;
 }
 
 /**
@@ -99,6 +110,15 @@ export interface PartialConversionSettings {
    * fail the guard.
    */
   readonly referenceExcludes?: Iterable<string>;
+  /**
+   * The style of imports to use in conversion:
+   *
+   * - "name": import by npm package name
+   *   (example) '@polymer/polymer/polymer-element.js'
+   * - "path": import by relative path
+   *   (example) '../../../@polymer/polymer/polymer-element.js'
+   */
+  readonly npmImportStyle?: NpmImportStyle;
 }
 
 /**
@@ -145,6 +165,9 @@ export function createDefaultConversionSettings(
     ],
   ]);
 
+  // Configure "npmImportStyle":
+  const npmImportStyle = options.npmImportStyle || 'path';
+
   // Return configured settings.
   return {
     namespaces,
@@ -152,5 +175,6 @@ export function createDefaultConversionSettings(
     includes,
     referenceExcludes,
     referenceRewrites,
+    npmImportStyle,
   };
 }

--- a/src/document-converter.ts
+++ b/src/document-converter.ts
@@ -1104,8 +1104,17 @@ export class DocumentConverter {
     if (originalHtmlImportUrl && path.posix.isAbsolute(originalHtmlImportUrl)) {
       return '/' + toUrl.slice('./'.length);
     }
-    // Return the external import URL formatted for paths.
-    return this.urlHandler.getPathImportUrl(this.convertedUrl, toUrl);
+    // If the import is contained within a single package (internal), return
+    // a path-based import.
+    if (this.urlHandler.isImportInternal(this.convertedUrl, toUrl)) {
+      return this.urlHandler.getPathImportUrl(this.convertedUrl, toUrl);
+    }
+    // Otherwise, return the external import URL formatted for names or paths.
+    if (this.conversionSettings.npmImportStyle === 'name') {
+      return this.urlHandler.getNameImportUrl(toUrl);
+    } else {
+      return this.urlHandler.getPathImportUrl(this.convertedUrl, toUrl);
+    }
   }
 
   /**

--- a/src/urls/package-url-handler.ts
+++ b/src/urls/package-url-handler.ts
@@ -114,7 +114,7 @@ export class PackageUrlHandler implements UrlHandler {
   }
 
   /**
-   * Get the formatted import URL between two ConvertedDocumentUrls.
+   * Get the formatted relative import URL between two ConvertedDocumentUrls.
    */
   getPathImportUrl(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       string {
@@ -145,5 +145,14 @@ export class PackageUrlHandler implements UrlHandler {
     }
 
     return importUrl;
+  }
+
+  /**
+   * Get the formatted import URL for a name-based conversion.
+   *
+   * Ex: `./node_modules/@polymer/polymer/foo.js` -> `@polymer/polymer/foo.js`
+   */
+  getNameImportUrl(url: ConvertedDocumentUrl): ConvertedDocumentUrl {
+    return url.slice('./node_modules/'.length) as ConvertedDocumentUrl;
   }
 }

--- a/src/urls/url-handler.ts
+++ b/src/urls/url-handler.ts
@@ -26,6 +26,7 @@ export interface UrlHandler {
   getPackageTypeForUrl(url: OriginalDocumentUrl): PackageType;
   isImportInternal(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       boolean;
+  getNameImportUrl(url: ConvertedDocumentUrl): ConvertedDocumentUrl;
   getPathImportUrl(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       string;
   convertUrl(url: OriginalDocumentUrl): ConvertedDocumentUrl;

--- a/src/urls/workspace-url-handler.ts
+++ b/src/urls/workspace-url-handler.ts
@@ -125,11 +125,21 @@ export class WorkspaceUrlHandler implements UrlHandler {
     return './' + jsUrlPieces.join('/') as ConvertedDocumentUrl;
   }
 
+
   /**
-   * Get the formatted import URL between two ConvertedDocumentUrls.
+   * Get the formatted relative import URL between two ConvertedDocumentUrls.
    */
   getPathImportUrl(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       string {
     return getRelativeUrl(fromUrl, toUrl);
+  }
+
+  /**
+   * Get the formatted import URL for a name-based conversion.
+   *
+   * Ex: `./@polymer/polymer/foo.js` -> `@polymer/polymer/foo.js`
+   */
+  getNameImportUrl(url: ConvertedDocumentUrl): ConvertedDocumentUrl {
+    return url.slice('./'.length) as ConvertedDocumentUrl;
   }
 }


### PR DESCRIPTION
*A part of #217: "Refactor ProjectConverter to Fix URL Handling"*
*Builds off of #224: "[ProjectConverter] Refactor BaseConverter into UrlHandler, ProjectConverter"*

## Summary:

Adds the CLI option `--import-by-name` to format npm package imports using names instead of paths.