### PR TITLE
Fix: out directory default to cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ add the new ones in the current directory:
 
 ```sh
 bower cache clean && bower install
-modulizer --out .
+modulizer
 ```
 
 ### Workspace mode
@@ -171,4 +171,4 @@ cd ../polymer
 modulizer
 ```
 
-The converted files are now in the directory `js_out`
+The converted files are now in the current working directory

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -22,7 +22,7 @@ import {exec, logStep} from '../util';
 
 export default async function run(options: CliOptions) {
   const inDir = path.resolve(options.in || process.cwd());
-  const outDir = path.resolve(options.out);
+  const outDir = path.resolve(options.out || process.cwd());
 
   // Ok, we're updating a package in a directory not under our control.
   // We need to be sure it's safe.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -58,7 +58,6 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
   {
     name: 'out',
     type: String,
-    defaultValue: 'modulizer_out',
     description: 'The directory to write converted files to.'
   },
   {name: 'in', type: String, description: 'The directory to convert.'},


### PR DESCRIPTION
Fixes #140 

Defaults the `outDir` to the cwd instead of `modulizer_out`