### PR TITLE
New: Check for SPDX license

### DIFF
--- a/custom_typings/spdx-license-list.d.ts
+++ b/custom_typings/spdx-license-list.d.ts
@@ -1,0 +1,4 @@
+declare module "spdx-license-list/simple" {
+  const simple: Set<String>;
+  export = simple;
+}

--- a/fixtures/packages/iron-icon/expected/package.json
+++ b/fixtures/packages/iron-icon/expected/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git://github.com/PolymerElements/iron-icon.git"
   },
-  "license": "http://polymer.github.io/LICENSE.txt",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "@polymer/iron-flex-layout": "^3.0.0-pre.1",
     "@polymer/iron-meta": "^3.0.0-pre.1",

--- a/fixtures/packages/paper-button/expected/package.json
+++ b/fixtures/packages/paper-button/expected/package.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "git://github.com/PolymerElements/paper-button.git"
   },
-  "license": "http://polymer.github.io/LICENSE.txt",
+  "license": "BSD-3-Clause",
   "homepage": "https://github.com/PolymerElements/paper-button",
   "dependencies": {
     "@polymer/polymer": "^3.0.0-pre.1",

--- a/fixtures/packages/polymer/expected/package.json
+++ b/fixtures/packages/polymer/expected/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/Polymer/polymer.git"
   },
-  "license": "http://polymer.github.io/LICENSE.txt",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "@webcomponents/shadycss": "^1.0.0",
     "@webcomponents/webcomponentsjs": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",
     "source-map-support": "^0.4.15",
+    "spdx-license-list": "^3.0.1",
     "tslib": "^1.7.1"
   },
   "devDependencies": {

--- a/src/manifest-converter.ts
+++ b/src/manifest-converter.ts
@@ -16,6 +16,7 @@
 
 import * as fs from 'mz/fs';
 import * as path from 'path';
+import * as spdxLicenseList from 'spdx-license-list/simple';
 
 interface DependencyMapEntry {
   npm: string;
@@ -78,15 +79,20 @@ export function generatePackageJson(
     license: bowerJson.license,
     homepage: bowerJson.homepage,
     dependencies: <any>{},
-    devDependencies: {}
+    devDependencies: <any>{}
   };
+
+  if (bowerJson.license.includes('polymer.github.io/LICENSE')) {
+    packageJson.license = 'BSD-3-Clause';
+  } else if (!spdxLicenseList.has(bowerJson.license)) {
+    console.warn(`"${bowerJson.license}" is not a valid SPDX license`);
+  }
 
   for (const bowerPackageName in bowerJson.dependencies) {
     const depInfo = lookupDependencyMapping(bowerPackageName);
-    if (!depInfo) {
-      continue;
+    if (depInfo) {
+      packageJson.dependencies[depInfo.npm] = depInfo.semver;
     }
-    packageJson.dependencies[depInfo.npm] = depInfo.semver;
   }
 
   // TODO(fks) 07-18-2017: handle devDependencies. Right now wct creates a too

--- a/src/manifest-converter.ts
+++ b/src/manifest-converter.ts
@@ -85,7 +85,8 @@ export function generatePackageJson(
   if (bowerJson.license.includes('polymer.github.io/LICENSE')) {
     packageJson.license = 'BSD-3-Clause';
   } else if (!spdxLicenseList.has(bowerJson.license)) {
-    console.warn(`"${bowerJson.license}" is not a valid SPDX license`);
+    console.warn(`"${bowerJson.license}" is not a valid SPDX license. ` +
+      `You can find a list of valid licenses at https://spdx.org/licenses/`);
   }
 
   for (const bowerPackageName in bowerJson.dependencies) {


### PR DESCRIPTION
Fixes #185 

Handles the polymer LICENSE URL => BSD-3-Clause
Warns user if the current license in bower is not a valid SPDX license. Perhaps further improvement could suggest the closest license?


**Open Questions:**

- How should we handle an existing `package.json` and `bower.json`, both having different licenses specified?
- Should we warn if no license has been specified or default to something like `Unlicense`?
- Would it be better to have a tedium process change the license on all PolymerElements from the Polymer License Url to BSD-3-Clause instead of having a custom logic branch built in here?