### PR TITLE
 Fix: Dedupe dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "build": "tsc",
     "build:fixtures": "npm run build && node lib/tools/update-fixtures",
-    "test:full": "npm run build && mocha lib/test/*_test.js lib/test/**/*_test.js && npm run lint",
-    "test:fast": "npm run build && mocha lib/test/unit/*_test.js lib/test/unit/**/*_test.js",
+    "test:full": "npm run build && mocha $(find lib/test -name *_test.js) && npm run lint",
+    "test:fast": "npm run build && mocha $(find lib/test/unit -name *_test.js)",
     "test:watch": "watchy -w src/ -w custom_typings/ -- npm run test:fast --loglevel=silent",
     "test": "npm run test:fast && npm run lint",
     "lint": "tslint -p ./",

--- a/src/manifest-converter.ts
+++ b/src/manifest-converter.ts
@@ -26,15 +26,17 @@ interface DependencyMap {
 }
 const dependencyMap: DependencyMap =
     readJson(__dirname, '../dependency-map.json');
+const warningCache: Set<String> = new Set();
 
 /**
  * Lookup the corresponding npm package name in our local map. By default, this
  * method will log a standard warning message to the user if no mapping was
  * found.
  */
-export function lookupDependencyMapping(bowerPackageName: string, warn = true) {
+export function lookupDependencyMapping(bowerPackageName: string) {
   const result = dependencyMap[bowerPackageName];
-  if (!result && warn) {
+  if (!result && !warningCache.has(bowerPackageName)) {
+    warningCache.add(bowerPackageName);
     console.warn(
         `WARN: bower->npm mapping for "${bowerPackageName}" not found`);
   }

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -19,10 +19,10 @@ import {Analyzer, InMemoryOverlayUrlLoader} from 'polymer-analyzer';
 
 import {createDefaultConversionSettings, PartialConversionSettings} from '../../conversion-settings';
 import {getPackageDocuments} from '../../convert-package';
+import {getMemberPath} from '../../document-util';
 import {ProjectConverter} from '../../project-converter';
 import {PackageUrlHandler} from '../../urls/package-url-handler';
 import {PackageType} from '../../urls/types';
-import {getMemberPath} from '../../document-util';
 
 /*
 A few conventions in these tests:
@@ -150,9 +150,7 @@ suite('AnalysisConverter', () => {
         'dep.html': `<h1>Hi</h1>`,
         'bower_components/dep/dep.html': `<h1>Hi</h1>`,
       });
-      // Warnings are non memoized, duplicates are expected
       const expectedWarnings = [
-        `WARN: bower->npm mapping for "dep" not found`,
         `WARN: bower->npm mapping for "dep" not found`,
       ];
       assertSources(await convert({expectedWarnings}), {
@@ -1747,13 +1745,15 @@ setBaz(foo + 10 * (10 ** 10));
           console.log('hello world');
         `
       });
-      const expectedWarnings = [`WARN: bower->npm mapping for "foo" not found`];
+      let expectedWarnings = [`WARN: bower->npm mapping for "foo" not found`];
       assertSources(await convert({packageName: 'polymer', expectedWarnings}), {
         'index.html': `
 
           <script src="../foo/foo.js"></script>
         `,
       });
+      // Warnings are memoized, duplicates are not expected
+      expectedWarnings = [];
       assertSources(
           await convert({packageName: '@polymer/polymer', expectedWarnings}), {
             'index.html': `


### PR DESCRIPTION
Deduplicated warnings for dependencies.
Removed the `warn` flag since it wasn't utilized anywhere.
Ran formatter.
Cleaned up globs into a lookup. (Separated this in a commit for easy revert if you don't like it)

If you would like `warn` re-added, what would its function be? At this point it seems like it would be forcing display of the warning regardless of the de-duplication.