### PR TITLE
run tests across workspace repos!

### DIFF
--- a/dependency-map.json
+++ b/dependency-map.json
@@ -492,7 +492,11 @@
     "semver": "^1.0.0"
   },
   "web-component-tester": {
-    "npm": "web-component-tester",
-    "semver": "^6.0.0"
+    "npm": "wct-browser-legacy",
+    "semver": "0.0.1-pre.10"
+  },
+  "web-animations-js": {
+    "npm": "web-animations-js",
+    "semver": "^2.3.1"
   }
 }

--- a/fixtures/packages/iron-icon/expected/package.json
+++ b/fixtures/packages/iron-icon/expected/package.json
@@ -22,5 +22,19 @@
     "@polymer/iron-meta": "^3.0.0-pre.1",
     "@polymer/polymer": "^3.0.0-pre.1"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@polymer/promise-polyfill": "^3.0.0-pre.1",
+    "@polymer/iron-iconset": "^3.0.0-pre.1",
+    "@polymer/iron-icons": "^3.0.0-pre.1",
+    "@polymer/iron-component-page": "^3.0.0-pre.1",
+    "wct-browser-legacy": "0.0.1-pre.10",
+    "@webcomponents/webcomponentsjs": "^1.0.0",
+    "@polymer/iron-demo-helpers": "^3.0.0-pre.1"
+  },
+  "resolutions": {
+    "inherits": "2.0.3",
+    "samsam": "1.1.3",
+    "supports-color": "3.1.2",
+    "type-detect": "1.0.0"
+  }
 }

--- a/fixtures/packages/iron-icon/expected/test/index.html
+++ b/fixtures/packages/iron-icon/expected/test/index.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <meta charset="utf-8">
   <title>Tests</title>
-  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../../wct-browser-legacy/browser.js"></script>
 
 </head>
 <body>

--- a/fixtures/packages/iron-icon/expected/test/iron-icon.html
+++ b/fixtures/packages/iron-icon/expected/test/iron-icon.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <script src="../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../../wct-browser-legacy/browser.js"></script>
   <script src="../../../@polymer/test-fixture/test-fixture-mocha.js"></script>
 
   <script type="module" src="../iron-icon.js"></script>

--- a/fixtures/packages/paper-button/expected/package.json
+++ b/fixtures/packages/paper-button/expected/package.json
@@ -26,5 +26,20 @@
     "@polymer/paper-behaviors": "^3.0.0-pre.1",
     "@polymer/paper-styles": "^3.0.0-pre.1"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@polymer/iron-component-page": "^3.0.0-pre.1",
+    "@polymer/iron-demo-helpers": "^3.0.0-pre.1",
+    "@polymer/iron-icon": "^3.0.0-pre.1",
+    "@polymer/iron-icons": "^3.0.0-pre.1",
+    "@polymer/iron-test-helpers": "^3.0.0-pre.1",
+    "@polymer/test-fixture": "^3.0.0-pre.1",
+    "wct-browser-legacy": "0.0.1-pre.10",
+    "@webcomponents/webcomponentsjs": "^1.0.0"
+  },
+  "resolutions": {
+    "inherits": "2.0.3",
+    "samsam": "1.1.3",
+    "supports-color": "3.1.2",
+    "type-detect": "1.0.0"
+  }
 }

--- a/fixtures/packages/paper-button/expected/test/index.html
+++ b/fixtures/packages/paper-button/expected/test/index.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>paper-button tests</title>
-  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../../wct-browser-legacy/browser.js"></script>
 </head>
 <body>
   <script>

--- a/fixtures/packages/paper-button/expected/test/paper-button.html
+++ b/fixtures/packages/paper-button/expected/test/paper-button.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
   <script src="../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../../wct-browser-legacy/browser.js"></script>
   <script src="../../../@polymer/iron-test-helpers/mock-interactions.js"></script>
 
   <script type="module" src="../paper-button.js"></script>

--- a/fixtures/packages/polymer/expected/package.json
+++ b/fixtures/packages/polymer/expected/package.json
@@ -14,5 +14,14 @@
     "@webcomponents/shadycss": "^1.0.0",
     "@webcomponents/webcomponentsjs": "^1.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "wct-browser-legacy": "0.0.1-pre.10",
+    "@polymer/test-fixture": "^3.0.0-pre.1"
+  },
+  "resolutions": {
+    "inherits": "2.0.3",
+    "samsam": "1.1.3",
+    "supports-color": "3.1.2",
+    "type-detect": "1.0.0"
+  }
 }

--- a/fixtures/packages/polymer/expected/test/runner.html
+++ b/fixtures/packages/polymer/expected/test/runner.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
   </script>
-  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../../wct-browser-legacy/browser.js"></script>
 </head>
 <body>
   <script>

--- a/fixtures/packages/polymer/expected/test/unit/array-selector.html
+++ b/fixtures/packages/polymer/expected/test/unit/array-selector.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./array-selector-elements.js"></script>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/async.html
+++ b/fixtures/packages/polymer/expected/test/unit/async.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../lib/utils/async.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/attributes.html
+++ b/fixtures/packages/polymer/expected/test/unit/attributes.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./attributes-elements.js"></script>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/behaviors.html
+++ b/fixtures/packages/polymer/expected/test/unit/behaviors.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/case-map.html
+++ b/fixtures/packages/polymer/expected/test/unit/case-map.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../lib/utils/case-map.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/configure.html
+++ b/fixtures/packages/polymer/expected/test/unit/configure.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/css-parse.html
+++ b/fixtures/packages/polymer/expected/test/unit/css-parse.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="utf-8">
 
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
 
   <title>css-parse</title>
 

--- a/fixtures/packages/polymer/expected/test/unit/custom-style-async.html
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style-async.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/custom-style-late.html
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style-late.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/custom-style-scope-cache.html
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style-scope-cache.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/custom-style.html
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./custom-style-import.js"></script>
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/debounce.html
+++ b/fixtures/packages/polymer/expected/test/unit/debounce.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/dir.html
+++ b/fixtures/packages/polymer/expected/test/unit/dir.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html dir="rtl">
 <head>
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="../../lib/mixins/dir-mixin.js"></script>
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/dom-bind.html
+++ b/fixtures/packages/polymer/expected/test/unit/dom-bind.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
 </head>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/dom-if.html
+++ b/fixtures/packages/polymer/expected/test/unit/dom-if.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./dom-if-elements.js"></script>
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/dom-repeat.html
+++ b/fixtures/packages/polymer/expected/test/unit/dom-repeat.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./dom-repeat-elements.js"></script>
   <style>

--- a/fixtures/packages/polymer/expected/test/unit/dynamic-import.html
+++ b/fixtures/packages/polymer/expected/test/unit/dynamic-import.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="./dynamic-imports/dynamic-element.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/events.html
+++ b/fixtures/packages/polymer/expected/test/unit/events.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="UTF-8">
 
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./events-elements.js"></script>

--- a/fixtures/packages/polymer/expected/test/unit/flattened-nodes-observer.html
+++ b/fixtures/packages/polymer/expected/test/unit/flattened-nodes-observer.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer-element.js"></script>
   <script type="module" src="../../lib/utils/flattened-nodes-observer.js"></script>
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/gestures.html
+++ b/fixtures/packages/polymer/expected/test/unit/gestures.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="utf-8">
 
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./gestures-elements.js"></script>

--- a/fixtures/packages/polymer/expected/test/unit/globals.html
+++ b/fixtures/packages/polymer/expected/test/unit/globals.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
   <script type="module">
 import '../../polymer.js';

--- a/fixtures/packages/polymer/expected/test/unit/importHref.html
+++ b/fixtures/packages/polymer/expected/test/unit/importHref.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../lib/utils/import-href.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/inheritance.html
+++ b/fixtures/packages/polymer/expected/test/unit/inheritance.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/logging.html
+++ b/fixtures/packages/polymer/expected/test/unit/logging.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/mixin-behaviors.html
+++ b/fixtures/packages/polymer/expected/test/unit/mixin-behaviors.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/mixin-utils.html
+++ b/fixtures/packages/polymer/expected/test/unit/mixin-utils.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/path-effects.html
+++ b/fixtures/packages/polymer/expected/test/unit/path-effects.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./path-effects-elements.js"></script>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/path.html
+++ b/fixtures/packages/polymer/expected/test/unit/path.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../lib/utils/path.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/polymer-dom-observeNodes.html
+++ b/fixtures/packages/polymer/expected/test/unit/polymer-dom-observeNodes.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/polymer-dom.html
+++ b/fixtures/packages/polymer/expected/test/unit/polymer-dom.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply.html
+++ b/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="./polymer-element-with-apply-import.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/polymer.element.html
+++ b/fixtures/packages/polymer/expected/test/unit/polymer.element.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer-element.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/polymer.legacyelement.html
+++ b/fixtures/packages/polymer/expected/test/unit/polymer.legacyelement.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/property-accessors.html
+++ b/fixtures/packages/polymer/expected/test/unit/property-accessors.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/property-effects-template.html
+++ b/fixtures/packages/polymer/expected/test/unit/property-effects-template.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer-element.js"></script>
   <script type="module" src="../../lib/mixins/gesture-event-listeners.js"></script>
   <script type="module" src="../../lib/elements/dom-if.js"></script>

--- a/fixtures/packages/polymer/expected/test/unit/property-effects.html
+++ b/fixtures/packages/polymer/expected/test/unit/property-effects.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./property-effects-elements.js"></script>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/ready-attached-order-class.html
+++ b/fixtures/packages/polymer/expected/test/unit/ready-attached-order-class.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/ready-attached-order.html
+++ b/fixtures/packages/polymer/expected/test/unit/ready-attached-order.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/render-status.html
+++ b/fixtures/packages/polymer/expected/test/unit/render-status.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 <body>
 

--- a/fixtures/packages/polymer/expected/test/unit/resolveurl.html
+++ b/fixtures/packages/polymer/expected/test/unit/resolveurl.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="UTF-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script>
     Polymer = {
       rootPath: 'earlyRootPath/'

--- a/fixtures/packages/polymer/expected/test/unit/shady-content.html
+++ b/fixtures/packages/polymer/expected/test/unit/shady-content.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
   </script>
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/shady-dynamic.html
+++ b/fixtures/packages/polymer/expected/test/unit/shady-dynamic.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
   </script>
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/shady-events.html
+++ b/fixtures/packages/polymer/expected/test/unit/shady-events.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   };
 </script>
 <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-<script src="../../../../web-component-tester/browser.js"></script>
+<script src="../../../../wct-browser-legacy/browser.js"></script>
 <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/shady.html
+++ b/fixtures/packages/polymer/expected/test/unit/shady.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js" register="true" shadydom="true"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/styling-cross-scope-apply.html
+++ b/fixtures/packages/polymer/expected/test/unit/styling-cross-scope-apply.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/styling-cross-scope-unknown-host.html
+++ b/fixtures/packages/polymer/expected/test/unit/styling-cross-scope-unknown-host.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/styling-cross-scope-var.html
+++ b/fixtures/packages/polymer/expected/test/unit/styling-cross-scope-var.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <style>
   .variable-override {

--- a/fixtures/packages/polymer/expected/test/unit/styling-import.html
+++ b/fixtures/packages/polymer/expected/test/unit/styling-import.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./styling-import-shared-styles.js"></script>
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/styling-only-with-template.html
+++ b/fixtures/packages/polymer/expected/test/unit/styling-only-with-template.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 

--- a/fixtures/packages/polymer/expected/test/unit/styling-scoped.html
+++ b/fixtures/packages/polymer/expected/test/unit/styling-scoped.html
@@ -22,7 +22,7 @@ window.customElements.define = function(name, fn, options) {
 };
 customElements.defineOrder = order;
 </script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <style>
     #priority[style-scope=x-styled], #priority.style-scope.x-styled {

--- a/fixtures/packages/polymer/expected/test/unit/template-stamp.html
+++ b/fixtures/packages/polymer/expected/test/unit/template-stamp.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="UTF-8">
 
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../../lib/mixins/template-stamp.js"></script>
 </head>

--- a/fixtures/packages/polymer/expected/test/unit/template-whitespace.html
+++ b/fixtures/packages/polymer/expected/test/unit/template-whitespace.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
 </head>
 <body>

--- a/fixtures/packages/polymer/expected/test/unit/templatize.html
+++ b/fixtures/packages/polymer/expected/test/unit/templatize.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../wct-browser-legacy/browser.js"></script>
   <script type="module" src="../../polymer.js"></script>
   <script type="module" src="./templatize-elements.js"></script>
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "polymer-modulizer",
   "version": "0.3.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/chai": {
       "version": "3.5.2",
@@ -11,7 +12,10 @@
     "@types/chai-subset": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
-      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A=="
+      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+      "requires": {
+        "@types/chai": "3.5.2"
+      }
     },
     "@types/chalk": {
       "version": "0.4.31",
@@ -47,12 +51,18 @@
     "@types/esprima": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-2.1.35.tgz",
-      "integrity": "sha512-wY9y8ircyGStLJjj9SWos6rjBY5uJmz2dlLUoqC7RYqvEjgRxxFYiyBU6Wu/H7XfuMhLfcJexDZ+hAXA6uHvSw=="
+      "integrity": "sha512-wY9y8ircyGStLJjj9SWos6rjBY5uJmz2dlLUoqC7RYqvEjgRxxFYiyBU6Wu/H7XfuMhLfcJexDZ+hAXA6uHvSw==",
+      "requires": {
+        "@types/estree": "0.0.38"
+      }
     },
     "@types/estraverse": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/estraverse/-/estraverse-0.0.6.tgz",
-      "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE="
+      "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE=",
+      "requires": {
+        "@types/estree": "0.0.38"
+      }
     },
     "@types/estree": {
       "version": "0.0.38",
@@ -62,12 +72,20 @@
     "@types/glob": {
       "version": "5.0.33",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A=="
+      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "requires": {
+        "@types/minimatch": "3.0.1",
+        "@types/node": "8.0.53"
+      }
     },
     "@types/inquirer": {
       "version": "0.0.35",
       "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.35.tgz",
-      "integrity": "sha512-/6WyyGROIw6qCmS8KmQtyt9Tj1OX7xIrGloAwMMOaNb3W/+QrrlL4Be4TDvLO4dlvw8gFrHfeXiWxS/k82jgEQ=="
+      "integrity": "sha512-/6WyyGROIw6qCmS8KmQtyt9Tj1OX7xIrGloAwMMOaNb3W/+QrrlL4Be4TDvLO4dlvw8gFrHfeXiWxS/k82jgEQ==",
+      "requires": {
+        "@types/rx": "4.1.1",
+        "@types/through": "0.0.29"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.1",
@@ -77,7 +95,10 @@
     "@types/mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha512-XA4vNO6GCBz8Smq0hqSRo4yRWMqr4FPQrWjhJt6nKskzly4/p87SfuJMFYGRyYb6jo2WNIQU2FDBsY5r1BibUA=="
+      "integrity": "sha512-XA4vNO6GCBz8Smq0hqSRo4yRWMqr4FPQrWjhJt6nKskzly4/p87SfuJMFYGRyYb6jo2WNIQU2FDBsY5r1BibUA==",
+      "requires": {
+        "@types/node": "8.0.53"
+      }
     },
     "@types/mocha": {
       "version": "2.2.44",
@@ -88,7 +109,10 @@
     "@types/mz": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.31.tgz",
-      "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I="
+      "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
+      "requires": {
+        "@types/node": "8.0.53"
+      }
     },
     "@types/node": {
       "version": "8.0.53",
@@ -98,17 +122,38 @@
     "@types/parse5": {
       "version": "2.2.34",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
-      "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0="
+      "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
+      "requires": {
+        "@types/node": "8.0.53"
+      }
     },
     "@types/rimraf": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
-      "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ=="
+      "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
+      "requires": {
+        "@types/glob": "5.0.33",
+        "@types/node": "8.0.53"
+      }
     },
     "@types/rx": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
-      "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg="
+      "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4",
+        "@types/rx-lite": "4.0.5",
+        "@types/rx-lite-aggregates": "4.0.3",
+        "@types/rx-lite-async": "4.0.2",
+        "@types/rx-lite-backpressure": "4.0.3",
+        "@types/rx-lite-coincidence": "4.0.3",
+        "@types/rx-lite-experimental": "4.0.1",
+        "@types/rx-lite-joinpatterns": "4.0.1",
+        "@types/rx-lite-testing": "4.0.1",
+        "@types/rx-lite-time": "4.0.3",
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
     },
     "@types/rx-core": {
       "version": "4.0.3",
@@ -118,57 +163,91 @@
     "@types/rx-core-binding": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
-      "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ=="
+      "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
+      "requires": {
+        "@types/rx-core": "4.0.3"
+      }
     },
     "@types/rx-lite": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.5.tgz",
-      "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w=="
+      "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w==",
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4"
+      }
     },
     "@types/rx-lite-aggregates": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
-      "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg=="
+      "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/rx-lite-async": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
-      "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw=="
+      "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/rx-lite-backpressure": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
-      "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA=="
+      "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/rx-lite-coincidence": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
-      "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ=="
+      "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/rx-lite-experimental": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
-      "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0="
+      "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/rx-lite-joinpatterns": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
-      "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4="
+      "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/rx-lite-testing": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
-      "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek="
+      "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
+      "requires": {
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
     },
     "@types/rx-lite-time": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
-      "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw=="
+      "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/rx-lite-virtualtime": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
-      "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg=="
+      "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
     },
     "@types/semver": {
       "version": "5.4.0",
@@ -178,7 +257,10 @@
     "@types/through": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
-      "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w=="
+      "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
+      "requires": {
+        "@types/node": "8.0.53"
+      }
     },
     "acorn": {
       "version": "4.0.13",
@@ -189,6 +271,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -201,6 +286,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      },
       "dependencies": {
         "semver": {
           "version": "5.0.3",
@@ -212,12 +301,20 @@
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc="
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "alter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80="
+      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+      "requires": {
+        "stable": "0.1.6"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -227,7 +324,10 @@
     "ansi-escape-sequences": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q=="
+      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+      "requires": {
+        "array-back": "2.0.0"
+      }
     },
     "ansi-escapes": {
       "version": "3.0.0",
@@ -242,7 +342,10 @@
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug=="
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "any-promise": {
       "version": "1.3.0",
@@ -253,12 +356,19 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8="
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -268,7 +378,10 @@
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw=="
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "requires": {
+        "typical": "2.6.1"
+      }
     },
     "array-unique": {
       "version": "0.2.1",
@@ -305,6 +418,11 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
@@ -319,7 +437,14 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -329,7 +454,10 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "supports-color": {
           "version": "2.0.0",
@@ -342,6 +470,54 @@
       "version": "5.8.38",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
       "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+      "requires": {
+        "babel-plugin-constant-folding": "1.0.1",
+        "babel-plugin-dead-code-elimination": "1.0.2",
+        "babel-plugin-eval": "1.0.1",
+        "babel-plugin-inline-environment-variables": "1.0.1",
+        "babel-plugin-jscript": "1.0.4",
+        "babel-plugin-member-expression-literals": "1.0.1",
+        "babel-plugin-property-literals": "1.0.1",
+        "babel-plugin-proto-to-assign": "1.0.4",
+        "babel-plugin-react-constant-elements": "1.0.3",
+        "babel-plugin-react-display-name": "1.0.3",
+        "babel-plugin-remove-console": "1.0.1",
+        "babel-plugin-remove-debugger": "1.0.1",
+        "babel-plugin-runtime": "1.0.7",
+        "babel-plugin-undeclared-variables-check": "1.0.2",
+        "babel-plugin-undefined-to-void": "1.1.6",
+        "babylon": "5.8.38",
+        "bluebird": "2.11.0",
+        "chalk": "1.1.3",
+        "convert-source-map": "1.5.0",
+        "core-js": "1.2.7",
+        "debug": "2.6.9",
+        "detect-indent": "3.0.1",
+        "esutils": "2.0.2",
+        "fs-readdir-recursive": "0.1.2",
+        "globals": "6.4.1",
+        "home-or-tmp": "1.0.0",
+        "is-integer": "1.0.7",
+        "js-tokens": "1.0.1",
+        "json5": "0.4.0",
+        "lodash": "3.10.1",
+        "minimatch": "2.0.10",
+        "output-file-sync": "1.1.2",
+        "path-exists": "1.0.0",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "regenerator": "0.8.40",
+        "regexpu": "1.3.0",
+        "repeating": "1.1.3",
+        "resolve": "1.5.0",
+        "shebang-regex": "1.0.0",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "source-map-support": "0.2.10",
+        "to-fast-properties": "1.0.3",
+        "trim-right": "1.0.1",
+        "try-resolve": "1.0.1"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
@@ -361,7 +537,14 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "lodash": {
           "version": "3.10.1",
@@ -372,18 +555,27 @@
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+          "requires": {
+            "source-map": "0.1.32"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY="
+              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+              "requires": {
+                "amdefine": "1.0.1"
+              }
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "supports-color": {
           "version": "2.0.0",
@@ -396,11 +588,24 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
       "dependencies": {
         "detect-indent": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "requires": {
+            "repeating": "2.0.1"
+          }
         },
         "jsesc": {
           "version": "1.3.0",
@@ -410,89 +615,174 @@
         "repeating": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "requires": {
+            "is-finite": "1.0.2"
+          }
         }
       }
     },
     "babel-helper-bindify-decorators": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA="
+      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ="
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8="
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo="
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-explode-class": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes="
+      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+      "requires": {
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-regex": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI="
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs="
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-constant-folding": {
       "version": "1.0.1",
@@ -533,6 +823,9 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
+      "requires": {
+        "lodash": "3.10.1"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -624,172 +917,329 @@
     "babel-plugin-transform-async-generator-functions": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds="
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E="
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-class-constructor-call": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk="
+      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+      "requires": {
+        "babel-plugin-syntax-class-constructor-call": "6.18.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw="
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-decorators": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0="
+      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+      "requires": {
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8="
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "requires": {
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4="
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos="
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ="
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo="
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM="
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg="
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
+      }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4="
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-export-extensions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM="
+      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+      "requires": {
+        "babel-plugin-syntax-export-extensions": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988="
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "requires": {
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY="
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8="
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "requires": {
+        "regenerator-transform": "0.10.1"
+      }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
     },
     "babel-plugin-undeclared-variables-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4="
+      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
+      "requires": {
+        "leven": "1.0.2"
+      }
     },
     "babel-plugin-undefined-to-void": {
       "version": "1.1.6",
@@ -799,32 +1249,106 @@
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk="
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
+      }
     },
     "babel-preset-stage-1": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
-      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A="
+      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+      "requires": {
+        "babel-plugin-transform-class-constructor-call": "6.24.1",
+        "babel-plugin-transform-export-extensions": "6.22.0",
+        "babel-preset-stage-2": "6.24.1"
+      }
     },
     "babel-preset-stage-2": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE="
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
+      }
     },
     "babel-preset-stage-3": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U="
+      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+      "requires": {
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
+      }
     },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      },
       "dependencies": {
         "babel-core": {
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g="
+          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.0",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
         },
         "core-js": {
           "version": "2.5.1",
@@ -834,7 +1358,11 @@
         "home-or-tmp": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-          "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
+          "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
         },
         "json5": {
           "version": "0.5.1",
@@ -844,7 +1372,10 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -852,6 +1383,10 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      },
       "dependencies": {
         "core-js": {
           "version": "2.5.1",
@@ -863,12 +1398,30 @@
     "babel-template": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI="
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
       "dependencies": {
         "globals": {
           "version": "9.18.0",
@@ -880,7 +1433,13 @@
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.18.0",
@@ -903,15 +1462,29 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
+    "bottleneck": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-1.16.0.tgz",
+      "integrity": "sha1-1s4TgIUnr8gLaQkvFWBmVeWyHxo="
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "breakable": {
       "version": "1.0.0",
@@ -944,17 +1517,31 @@
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60="
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc="
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
     },
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q=="
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.5.0"
+      }
     },
     "chardet": {
       "version": "0.4.0",
@@ -965,32 +1552,62 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "clang-format": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.1.0.tgz",
       "integrity": "sha512-0Aru49uTLoROl4sPTyO3fvF/NZ+fnGEy5i7bsRwA/bAYT+eWaAxK3sDxRvm/AW7Nwq83BvARH/npeF8OIAaGVQ==",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.5.0"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU="
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1000,7 +1617,12 @@
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE="
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      }
     },
     "clone": {
       "version": "2.1.1",
@@ -1010,7 +1632,10 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ=="
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
     },
     "color-name": {
       "version": "1.1.3",
@@ -1026,17 +1651,31 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "0.0.5"
+      }
     },
     "command-line-args": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA=="
+      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+      "requires": {
+        "array-back": "2.0.0",
+        "find-replace": "1.0.3",
+        "typical": "2.6.1"
+      }
     },
     "command-line-usage": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.0.1.tgz",
-      "integrity": "sha512-IqYzZuXizukrdhnbdUj2hh4iceycow+Jn10mER4lwU4IapYvl5ZzoRPsj5Yraew5oRk4yfFKMuULGvAfb5o29w=="
+      "integrity": "sha512-IqYzZuXizukrdhnbdUj2hh4iceycow+Jn10mER4lwU4IapYvl5ZzoRPsj5Yraew5oRk4yfFKMuULGvAfb5o29w==",
+      "requires": {
+        "ansi-escape-sequences": "4.0.0",
+        "array-back": "2.0.0",
+        "table-layout": "0.4.2",
+        "typical": "2.6.1"
+      }
     },
     "commander": {
       "version": "2.11.0",
@@ -1047,6 +1686,17 @@
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+      "requires": {
+        "commander": "2.11.0",
+        "detective": "4.5.0",
+        "glob": "5.0.15",
+        "graceful-fs": "4.1.11",
+        "iconv-lite": "0.4.19",
+        "mkdirp": "0.5.1",
+        "private": "0.1.8",
+        "q": "1.5.1",
+        "recast": "0.11.23"
+      },
       "dependencies": {
         "ast-types": {
           "version": "0.9.6",
@@ -1056,7 +1706,13 @@
         "recast": {
           "version": "0.11.23",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM="
+          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+          "requires": {
+            "ast-types": "0.9.6",
+            "esprima": "3.1.3",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
+          }
         }
       }
     },
@@ -1101,7 +1757,10 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1112,6 +1771,9 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "requires": {
+        "type-detect": "0.1.1"
+      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
@@ -1139,6 +1801,18 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+      "requires": {
+        "alter": "0.2.0",
+        "ast-traverse": "0.1.1",
+        "breakable": "1.0.0",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "0.1.0",
+        "simple-is": "0.2.0",
+        "stringmap": "0.2.2",
+        "stringset": "0.2.1",
+        "tryor": "0.1.2",
+        "yargs": "3.27.0"
+      },
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
@@ -1156,12 +1830,21 @@
     "detect-indent": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-      "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U="
+      "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+      "requires": {
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0",
+        "repeating": "1.1.3"
+      }
     },
     "detective": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE="
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "requires": {
+        "acorn": "4.0.13",
+        "defined": "1.0.0"
+      }
     },
     "diff": {
       "version": "3.4.0",
@@ -1174,6 +1857,13 @@
       "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-1.4.0.tgz",
       "integrity": "sha1-r6AKuZwPscQStI3GXo9DeNJX8AY=",
       "dev": true,
+      "requires": {
+        "bluebird": "3.4.1",
+        "buffer-equal": "1.0.0",
+        "colors": "1.0.3",
+        "commander": "2.9.0",
+        "minimatch": "3.0.2"
+      },
       "dependencies": {
         "bluebird": {
           "version": "3.4.1",
@@ -1191,25 +1881,42 @@
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
           "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM="
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "dom5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
       "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
+      "requires": {
+        "@types/clone": "0.1.30",
+        "@types/node": "6.0.92",
+        "@types/parse5": "2.2.34",
+        "clone": "2.1.1",
+        "parse5": "2.2.3"
+      },
       "dependencies": {
         "@types/node": {
           "version": "6.0.92",
@@ -1226,12 +1933,23 @@
     "escodegen": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw=="
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
+      }
     },
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "requires": {
+        "acorn": "5.2.1",
+        "acorn-jsx": "3.0.1"
+      },
       "dependencies": {
         "acorn": {
           "version": "5.2.1",
@@ -1258,12 +1976,18 @@
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -1273,12 +1997,20 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA=="
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "requires": {
+        "chardet": "0.4.0",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
+      }
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1288,7 +2020,10 @@
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI="
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1298,17 +2033,31 @@
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM="
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "find-replace": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "requires": {
+        "array-back": "1.0.4",
+        "test-value": "2.1.0"
+      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs="
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "requires": {
+            "typical": "2.6.1"
+          }
         }
       }
     },
@@ -1320,7 +2069,11 @@
     "follow-redirects": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk="
+      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+      "requires": {
+        "debug": "2.6.9",
+        "stream-consume": "0.1.0"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1330,13 +2083,21 @@
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "form-data": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
       "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
       "dev": true,
+      "requires": {
+        "async": "0.9.2",
+        "combined-stream": "0.0.7",
+        "mime-types": "2.0.14"
+      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -1368,6 +2129,10 @@
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -1379,7 +2144,11 @@
           "version": "4.11.8",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -1396,7 +2165,11 @@
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
         },
         "asn1": {
           "version": "0.2.3",
@@ -1437,22 +2210,35 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -1479,7 +2265,10 @@
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1499,13 +2288,19 @@
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1519,7 +2314,10 @@
           "version": "2.6.8",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -1548,7 +2346,10 @@
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "extend": {
           "version": "3.0.1",
@@ -1571,7 +2372,12 @@
           "version": "2.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1581,25 +2387,49 @@
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1612,7 +2442,15 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -1629,7 +2467,11 @@
           "version": "4.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -1640,7 +2482,13 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -1651,12 +2499,21 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1672,7 +2529,10 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -1695,7 +2555,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -1713,7 +2576,10 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -1732,6 +2598,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1749,12 +2621,18 @@
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -1764,7 +2642,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -1776,19 +2657,42 @@
           "version": "0.6.39",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -1810,7 +2714,10 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -1828,7 +2735,11 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -1863,6 +2774,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -1875,18 +2792,54 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -1914,13 +2867,27 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1930,15 +2897,23 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -1949,7 +2924,10 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -1960,25 +2938,46 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         },
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -2007,13 +3006,19 @@
           "version": "1.3.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -2030,22 +3035,42 @@
     "github": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/github/-/github-11.0.0.tgz",
-      "integrity": "sha1-7bMt9e+zPK0ATr8L3SpLMLtjqFQ="
+      "integrity": "sha1-7bMt9e+zPK0ATr8L3SpLMLtjqFQ=",
+      "requires": {
+        "follow-redirects": "0.0.7",
+        "https-proxy-agent": "1.0.0",
+        "mime": "1.4.1",
+        "netrc": "0.1.4"
+      }
     },
     "glob": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E="
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q="
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "6.4.1",
@@ -2073,6 +3098,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
@@ -2106,12 +3134,21 @@
     "home-or-tmp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-      "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU="
+      "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "user-home": "1.1.1"
+      }
     },
     "https-proxy-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY="
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -2126,7 +3163,11 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -2136,12 +3177,31 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ=="
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -2152,7 +3212,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.11.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -2167,7 +3230,10 @@
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ="
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -2182,7 +3248,10 @@
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -2192,17 +3261,26 @@
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
-      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw="
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -2227,7 +3305,10 @@
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "ix": {
       "version": "2.1.0",
@@ -2242,7 +3323,25 @@
     "jscodeshift": {
       "version": "0.3.32",
       "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
-      "integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs="
+      "integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
+      "requires": {
+        "async": "1.5.2",
+        "babel-core": "5.8.38",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-stage-1": "6.24.1",
+        "babel-register": "6.26.0",
+        "babylon": "6.18.0",
+        "colors": "1.1.2",
+        "flow-parser": "0.59.0",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11",
+        "node-dir": "0.1.8",
+        "nomnom": "1.8.1",
+        "recast": "0.12.9",
+        "temp": "0.8.3",
+        "write-file-atomic": "1.3.4"
+      }
     },
     "jsesc": {
       "version": "0.5.0",
@@ -2268,7 +3367,10 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -2278,7 +3380,10 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "leven": {
       "version": "1.0.2",
@@ -2288,7 +3393,11 @@
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4="
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -2299,7 +3408,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -2329,7 +3442,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -2347,7 +3465,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.padend": {
       "version": "4.6.1",
@@ -2363,6 +3486,9 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      },
       "dependencies": {
         "js-tokens": {
           "version": "3.0.2",
@@ -2380,7 +3506,22 @@
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
     },
     "mime": {
       "version": "1.4.1",
@@ -2397,7 +3538,10 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
       "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.12.0"
+      }
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -2407,7 +3551,10 @@
     "minimatch": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc="
+      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -2418,6 +3565,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -2431,18 +3581,38 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
       "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "commander": {
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
         },
         "debug": {
           "version": "2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "diff": {
           "version": "3.2.0",
@@ -2454,7 +3624,15 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
@@ -2466,13 +3644,19 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         },
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -2489,7 +3673,12 @@
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
+      }
     },
     "nan": {
       "version": "2.8.0",
@@ -2512,6 +3701,10 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "requires": {
+        "chalk": "0.4.0",
+        "underscore": "1.6.0"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
@@ -2521,7 +3714,12 @@
         "chalk": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8="
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "requires": {
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
+          }
         },
         "strip-ansi": {
           "version": "0.1.1",
@@ -2533,7 +3731,10 @@
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -2548,22 +3749,40 @@
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo="
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ="
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -2577,6 +3796,12 @@
       "resolved": "https://registry.npmjs.org/orgsync-logger/-/orgsync-logger-1.4.0.tgz",
       "integrity": "sha1-npupyCcRsQImkLIpOGjdwqSclD8=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.0",
+        "statsd-client": "0.2.1",
+        "superagent": "1.7.2",
+        "underscore": "1.8.3"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
@@ -2594,13 +3819,23 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "integrity": "sha1-CbRTzsSXp1Ug5KYK5IIUqHAOCSE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "supports-color": {
           "version": "2.0.0",
@@ -2624,7 +3859,10 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -2634,12 +3872,23 @@
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY="
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse5": {
       "version": "2.2.3",
@@ -2665,6 +3914,30 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.3.0.tgz",
       "integrity": "sha512-mgvLJ7hez52/Iy54GGFVRs9CoO0jXWeS2Iqows5GJpL+KnFiR1afziI2s/5teQcC53vtPUtWba8PEeQHroD5Hw==",
+      "requires": {
+        "@types/chai-subset": "1.3.1",
+        "@types/chalk": "0.4.31",
+        "@types/clone": "0.1.30",
+        "@types/cssbeautify": "0.3.1",
+        "@types/doctrine": "0.0.1",
+        "@types/escodegen": "0.0.2",
+        "@types/estraverse": "0.0.6",
+        "@types/estree": "0.0.37",
+        "@types/node": "6.0.92",
+        "@types/parse5": "2.2.34",
+        "chalk": "1.1.3",
+        "clone": "2.1.1",
+        "cssbeautify": "0.3.1",
+        "doctrine": "2.0.0",
+        "dom5": "2.3.0",
+        "escodegen": "1.9.0",
+        "espree": "3.5.2",
+        "estraverse": "4.2.0",
+        "jsonschema": "1.2.0",
+        "parse5": "2.2.3",
+        "shady-css-parser": "0.1.0",
+        "strip-indent": "2.0.0"
+      },
       "dependencies": {
         "@types/estree": {
           "version": "0.0.37",
@@ -2689,12 +3962,22 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "supports-color": {
           "version": "2.0.0",
@@ -2704,9 +3987,15 @@
       }
     },
     "polymer-workspaces": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/polymer-workspaces/-/polymer-workspaces-1.1.0.tgz",
-      "integrity": "sha512-XV1RAswBjZEO02d2FCB0MYODmqZnQpB2WM4BxSuT0hIo6w/0ISqbe8Cqbwoo9MC1Fpgz1HACbpm3pKBbhHMd3w=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/polymer-workspaces/-/polymer-workspaces-2.0.0.tgz",
+      "integrity": "sha512-wDLgvgfQMEQqRYup7eDsg+89maTgy+EIrXXHgz1kkC/XjObG3zvakS9EqmdUvEoTE36p9jRRcww2ZHUOAzJ/Mg==",
+      "requires": {
+        "@types/rimraf": "2.0.2",
+        "bottleneck": "1.16.0",
+        "github": "11.0.0",
+        "rimraf": "2.6.2"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -2744,23 +4033,36 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
             }
           }
         },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
         }
       }
     },
@@ -2768,19 +4070,37 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
+      },
       "dependencies": {
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -2788,6 +4108,13 @@
       "version": "0.12.9",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
       "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+      "requires": {
+        "ast-types": "0.10.1",
+        "core-js": "2.5.1",
+        "esprima": "4.0.0",
+        "private": "0.1.8",
+        "source-map": "0.6.1"
+      },
       "dependencies": {
         "ast-types": {
           "version": "0.10.1",
@@ -2831,6 +4158,14 @@
       "version": "0.8.40",
       "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
       "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+      "requires": {
+        "commoner": "0.10.8",
+        "defs": "1.1.1",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.8",
+        "recast": "0.10.33",
+        "through": "2.3.8"
+      },
       "dependencies": {
         "ast-types": {
           "version": "0.8.12",
@@ -2845,7 +4180,13 @@
         "recast": {
           "version": "0.10.33",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-          "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc="
+          "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+          "requires": {
+            "ast-types": "0.8.12",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
+          }
         }
       }
     },
@@ -2857,17 +4198,32 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q=="
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
+      }
     },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ=="
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
     },
     "regexpu": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
       "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+      "requires": {
+        "esprima": "2.7.3",
+        "recast": "0.10.43",
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      },
       "dependencies": {
         "ast-types": {
           "version": "0.8.15",
@@ -2883,6 +4239,12 @@
           "version": "0.10.43",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
           "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
+          "requires": {
+            "ast-types": "0.8.15",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
+          },
           "dependencies": {
             "esprima-fb": {
               "version": "15001.1001.0-dev-harmony-fb",
@@ -2896,7 +4258,12 @@
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "requires": {
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -2906,7 +4273,10 @@
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw="
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "requires": {
+        "jsesc": "0.5.0"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -2926,44 +4296,74 @@
     "repeating": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw="
+      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw=="
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368="
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8="
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA="
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -2973,7 +4373,10 @@
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74="
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -3035,7 +4438,15 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA=="
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "spdx-license-list": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-3.0.1.tgz",
+      "integrity": "sha1-Fj1yEj4A9Pi9bhgSVpawCfEkj/U="
     },
     "stable": {
       "version": "0.1.6",
@@ -3053,16 +4464,23 @@
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
     },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw=="
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringmap": {
       "version": "0.2.2",
@@ -3077,7 +4495,10 @@
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8="
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "3.0.0"
+      }
     },
     "strip-indent": {
       "version": "2.0.0",
@@ -3089,6 +4510,19 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
       "integrity": "sha1-Zfnu1PU2EyDJ2HRBKrd7666ktXI=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.0.6",
+        "debug": "2.6.9",
+        "extend": "3.0.0",
+        "form-data": "0.2.0",
+        "formidable": "1.0.17",
+        "methods": "1.1.2",
+        "mime": "1.3.4",
+        "qs": "2.3.3",
+        "readable-stream": "1.0.27-1",
+        "reduce-component": "1.0.1"
+      },
       "dependencies": {
         "extend": {
           "version": "3.0.0",
@@ -3112,7 +4546,13 @@
           "version": "1.0.27-1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
           "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -3125,17 +4565,31 @@
     "supports-color": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s="
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "requires": {
+        "has-flag": "2.0.0"
+      }
     },
     "table-layout": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg=="
+      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "requires": {
+        "array-back": "2.0.0",
+        "deep-extend": "0.5.0",
+        "lodash.padend": "4.6.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "3.0.0"
+      }
     },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
+      },
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
@@ -3148,23 +4602,36 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "requires": {
+        "array-back": "1.0.4",
+        "typical": "2.6.1"
+      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs="
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "requires": {
+            "typical": "2.6.1"
+          }
         }
       }
     },
     "thenify": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk="
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "1.3.0"
+      }
     },
     "thenify-all": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY="
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": "3.3.0"
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -3174,7 +4641,10 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -3206,18 +4676,42 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
       "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
+        "diff": "3.4.0",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.0",
+        "tsutils": "2.12.2"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -3225,12 +4719,18 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.2.tgz",
       "integrity": "sha1-rVikhl0X7D3bZjG2ylO+FKVlb/M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tslib": "1.8.0"
+      }
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I="
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "1.0.0",
@@ -3268,7 +4768,14 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/watchy/-/watchy-0.7.0.tgz",
       "integrity": "sha512-/9DPISHCreOYgcD3jXZI7Rfcu+bV1HYmoapWubFzolvXcGjEW7nl2VIzwleKc4T9/lNyDLe8H8As5bHi85Tj/A==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chokidar": "1.7.0",
+        "commander": "2.11.0",
+        "herit": "2.2.2",
+        "orgsync-logger": "1.4.0",
+        "underscore": "1.6.0"
+      }
     },
     "window-size": {
       "version": "0.1.4",
@@ -3283,7 +4790,11 @@
     "wordwrapjs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw=="
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "requires": {
+        "reduce-flatten": "1.0.1",
+        "typical": "2.6.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -3293,7 +4804,12 @@
     "write-file-atomic": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8="
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
     },
     "y18n": {
       "version": "3.2.1",
@@ -3303,7 +4819,15 @@
     "yargs": {
       "version": "3.27.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA="
+      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mkdirp": "^0.5.1",
     "mz": "^2.6.0",
     "polymer-analyzer": "~2.3.0",
-    "polymer-workspaces": "^1.0.0",
+    "polymer-workspaces": "^2.0.0",
     "recast": "^0.12.4",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -84,7 +84,7 @@ export default async function run(options: CliOptions) {
         }]))['npm-version'] as string;
   }
 
-  logStep('[1/2]', '🌀', `Converting Package...`);
+  logStep(1, 2, '🌀', `Converting Package...`);
   console.log(`Out directory: ${outDir}`);
   await convertPackage({
     inDir: inDir,
@@ -97,5 +97,5 @@ export default async function run(options: CliOptions) {
     cleanOutDir: options.clean!!,
   });
 
-  logStep('[2/2]', '🎉', `Conversion Complete!`);
+  logStep(2, 2, '🎉', `Conversion Complete!`);
 }

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -11,7 +11,6 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import chalk from 'chalk';
 import * as inquirer from 'inquirer';
 import * as path from 'path';
 import * as semver from 'semver';
@@ -19,7 +18,7 @@ import * as semver from 'semver';
 import {CliOptions} from '../cli';
 import convertPackage from '../convert-package';
 import {readJson} from '../manifest-converter';
-import {exec} from '../util';
+import {exec, logStep} from '../util';
 
 export default async function run(options: CliOptions) {
   const inDir = path.resolve(options.in || process.cwd());
@@ -85,10 +84,8 @@ export default async function run(options: CliOptions) {
         }]))['npm-version'] as string;
   }
 
-  console.log(
-      chalk.dim('[1/2]') + ' 🌀  ' + chalk.magenta(`Converting Package...`));
+  logStep('[1/2]', '🌀', `Converting Package...`);
   console.log(`Out directory: ${outDir}`);
-
   await convertPackage({
     inDir: inDir,
     outDir: outDir,
@@ -100,6 +97,5 @@ export default async function run(options: CliOptions) {
     cleanOutDir: options.clean!!,
   });
 
-  console.log(
-      chalk.dim('[2/2]') + ' 🎉  ' + chalk.magenta(`Conversion Complete!`));
+  logStep('[2/2]', '🎉', `Conversion Complete!`);
 }

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -12,13 +12,15 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import chalk from 'chalk';
 import * as fs from 'fs';
+import * as inquirer from 'inquirer';
 import * as path from 'path';
 import {Workspace} from 'polymer-workspaces';
 
 import {CliOptions} from '../cli';
 import convertWorkspace from '../convert-workspace';
+import {testWorkspace, testWorkspaceInstallOnly} from '../test-workspace';
+import {logStep} from '../util';
 
 const githubTokenMessage = `
 You need to create a github token and place it in a file named 'github-token'.
@@ -31,6 +33,31 @@ Then:
 echo 'PASTE TOKEN HEX HERE' > ./github-token
 `;
 
+/**
+ * Post-Conversion steps that the user can select to run after workspace
+ * conversion.
+ */
+enum PostConversionStep {
+  Test = 'test',
+  TestInstallOnly = 'test (install only)',
+  Quit = 'quit',
+}
+
+/**
+ * Create an array of post-conversion steps to run automatically from the given
+ * CLI options. For example, when `--test` is provided the "test"
+ * post-conversion step should be run without prompting.
+ *
+ * Steps should be run in the order returned.
+ */
+function postConversionStepsFromCliOptions(options: CliOptions):
+    PostConversionStep[] {
+  const steps = [];
+  if (options.test === true) {
+    steps.push(PostConversionStep.Test);
+  }
+  return steps;
+}
 
 /**
  * Checks for github-token in the RunnerOptions and if not specified, will look
@@ -56,9 +83,7 @@ function loadGitHubToken(): string|null {
 
 export default async function run(options: CliOptions) {
   const workspaceDir = path.resolve(options['workspace-dir']);
-  console.log(
-      chalk.dim('[1/3]') + ' 🚧  ' +
-      chalk.magenta(`Setting Up Workspace "${workspaceDir}"...`));
+  logStep('[1/3]', '🚧', `Setting Up Workspace "${workspaceDir}"...`);
 
   if (!options['npm-version']) {
     throw new Error('--npm-version required');
@@ -76,7 +101,7 @@ export default async function run(options: CliOptions) {
     dir: workspaceDir,
   });
 
-  const reposToConvert = await workspace.init(
+  const {workspaceRepos: reposToConvert} = await workspace.init(
       {
         include: options['repo']!,
         exclude: options['exclude'],
@@ -86,17 +111,59 @@ export default async function run(options: CliOptions) {
         verbose: true,
       });
 
-  console.log(
-      chalk.dim('[2/3]') + ' 🌀  ' +
-      chalk.magenta(`Converting ${reposToConvert.length} Package(s)...`));
+  await workspace.installBowerDependencies();
 
-  await convertWorkspace({
+  logStep('[2/3]', '🌀', `Converting ${reposToConvert.length} Package(s)...`);
+
+  const convertedPackages = await convertWorkspace({
     workspaceDir,
     npmImportStyle: options['import-style'],
     packageVersion: npmPackageVersion,
     reposToConvert,
   });
 
-  console.log(
-      chalk.dim('[3/3]') + ' 🎉  ' + chalk.magenta(`Conversion Complete!`));
+  logStep('[3/3]', '🎉', `Conversion Complete!`);
+
+  // Loop indefinitely here so that we can control the function exit via the
+  // user prompt.
+  const todoConversionSteps = postConversionStepsFromCliOptions(options);
+  while (true) {
+    // Pull off a "to-do" post-conversion step if any were provided from the
+    // command line, otherwise prompt the user for one.
+    const stepSelection = todoConversionSteps.shift() ||
+        (await inquirer.prompt([{
+          type: 'list',
+          name: 'post-conversion-step',
+          message: ' What do you want to do now?',
+          choices: [
+            PostConversionStep.Test,
+            PostConversionStep.TestInstallOnly,
+            PostConversionStep.Quit
+          ],
+        }]))['post-conversion-step'] as string;
+    switch (stepSelection) {
+      case PostConversionStep.Test:
+        await testWorkspace(convertedPackages, {
+          workspaceDir,
+          packageVersion: npmPackageVersion,
+          reposToConvert,
+        });
+        break;
+      case PostConversionStep.TestInstallOnly:
+        await testWorkspaceInstallOnly(convertedPackages, {
+          workspaceDir,
+          packageVersion: npmPackageVersion,
+          reposToConvert,
+        });
+        break;
+      // TODO(fks): Add 'push to github' support
+      // TODO(fks): Add 'publish to npm' support
+      case PostConversionStep.Quit:
+        console.log('👋  Goodbye.');
+        return;
+      default:
+        console.log(`ERR: option "${stepSelection}" not recognized`);
+        break;
+    }
+  }
 }

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -102,17 +102,13 @@ export default async function run(options: CliOptions) {
   const workspace = new Workspace({
     token: githubToken,
     dir: workspaceDir,
+    match: options['repo']!,
+    exclude: options['exclude'],
+    fresh: options['clean'],
+    verbose: true,
   });
 
-  const {workspaceRepos: reposToConvert} = await workspace.init(
-      {
-        include: options['repo']!,
-        exclude: options['exclude'],
-      },
-      {
-        fresh: options['clean'],
-        verbose: true,
-      });
+  const {workspaceRepos: reposToConvert} = await workspace.init();
 
   await workspace.installBowerDependencies();
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,6 +113,12 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
         `input directory.`,
   },
   {
+    name: 'test',
+    type: Boolean,
+    defaultValue: false,
+    description: `If given, run tests after workspace conversion.`,
+  },
+  {
     name: 'import-style',
     type: String,
     defaultValue: 'path',
@@ -137,6 +143,7 @@ export interface CliOptions {
   'workspace-dir': string;
   'github-token'?: string;
   force: boolean;
+  test: boolean;
   'import-style': NpmImportStyle;
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,6 +113,13 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
         `input directory.`,
   },
   {
+    name: 'install',
+    type: Boolean,
+    defaultValue: false,
+    description:
+        `If given, installs dependencies in all repos after workspace conversion.`,
+  },
+  {
     name: 'test',
     type: Boolean,
     defaultValue: false,
@@ -143,6 +150,7 @@ export interface CliOptions {
   'workspace-dir': string;
   'github-token'?: string;
   force: boolean;
+  install: boolean;
   test: boolean;
   'import-style': NpmImportStyle;
 }

--- a/src/manifest-converter.ts
+++ b/src/manifest-converter.ts
@@ -59,13 +59,13 @@ export function lookupDependencyMapping(bowerPackageName: string) {
 }
 
 function setNpmDependencyFromBower(
-    obj: any, bowerPackageName: string, preferLocal?: Map<string, string>) {
+    obj: any, bowerPackageName: string, useLocal?: Map<string, string>) {
   const depInfo = lookupDependencyMapping(bowerPackageName);
   if (!depInfo) {
     return;
   }
-  if (preferLocal && preferLocal.has(depInfo.npm)) {
-    obj[depInfo.npm] = getLocalDependencyValue(preferLocal.get(depInfo.npm)!);
+  if (useLocal && useLocal.has(depInfo.npm)) {
+    obj[depInfo.npm] = getLocalDependencyValue(useLocal.get(depInfo.npm)!);
   } else {
     obj[depInfo.npm] = depInfo.semver;
   }
@@ -92,7 +92,7 @@ export function writeJson(json: any, ...pathPieces: string[]) {
 /**
  * Given a bower.json manifest, generate a package.json manifest for npm.
  *
- * Function takes an optional `preferLocal` argument containing a map of any
+ * Function takes an optional `useLocal` argument containing a map of any
  * npm dependencies (name -> local file path) that should be referenced via
  * local file path and not public package name in the package.json. This is
  * useful for testing against other, converted repos.
@@ -101,7 +101,7 @@ export function generatePackageJson(
     bowerJson: any,
     npmName: string,
     npmVersion: string,
-    preferLocal?: Map<string, string>) {
+    useLocal?: Map<string, string>) {
   const packageJson = {
     name: npmName,
     flat: true,
@@ -136,11 +136,11 @@ export function generatePackageJson(
 
   for (const bowerPackageName in bowerJson.dependencies) {
     setNpmDependencyFromBower(
-        packageJson.dependencies, bowerPackageName, preferLocal);
+        packageJson.dependencies, bowerPackageName, useLocal);
   }
   for (const bowerPackageName in bowerJson.devDependencies) {
     setNpmDependencyFromBower(
-        packageJson.devDependencies, bowerPackageName, preferLocal);
+        packageJson.devDependencies, bowerPackageName, useLocal);
   }
 
   return packageJson;

--- a/src/test-workspace.ts
+++ b/src/test-workspace.ts
@@ -71,7 +71,6 @@ async function testRepos(reposUnderTest: WorkspaceRepo[]) {
   return run(reposUnderTest, async (repo) => {
     const repoDirName = path.basename(repo.dir);
     const {stdout, stderr} = await exec(repo.dir, 'wct', ['--npm']);
-    console.log(stdout, stderr);
     if (stdout.length > 0) {
       console.log(chalk.dim(`${repoDirName}: ${stdout}`));
     }
@@ -130,7 +129,7 @@ export async function testWorkspace(
   testResults.failures.forEach(logRepoError);
 
   logStep(4, 5, '🔧', `Restoring Repos...`);
-  const restoreResults = await restoreRepos([...testResults.successes.keys()]);
+  const restoreResults = await restoreRepos(allRepos);
   restoreResults.failures.forEach(logRepoError);
 
   logStep(5, 5, '🔧', `Tests Complete!`);

--- a/src/test-workspace.ts
+++ b/src/test-workspace.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import chalk from 'chalk';
+import * as path from 'path';
+import {run, WorkspaceRepo} from 'polymer-workspaces';
+
+import {WorkspaceConversionSettings} from './convert-workspace';
+import {generatePackageJson, localDependenciesBranch, readJson, writeJson} from './manifest-converter';
+import {lookupNpmPackageName} from './urls/workspace-url-handler';
+import {exec, logRepoError, logStep} from './util';
+
+/**
+ * Configuration options required for workspace testing. Same as conversion
+ * settings.
+ */
+interface WorkspaceTestSettings extends WorkspaceConversionSettings {}
+
+/**
+ * Setup the workspace repos for testing. Be sure to call restoreRepos() after
+ * testing is complete.
+ */
+async function setupRepos(
+    reposUnderTest: WorkspaceRepo[],
+    localConversionMap: Map<string, string>,
+    options: WorkspaceTestSettings) {
+  // Yarn sometimes has some issues with bad packages entering the cache from
+  // modulizer. Clear the cache before starting.
+  const {stderr} = await exec(options.workspaceDir, 'yarn', ['cache', 'clean']);
+  if (stderr.length > 0) {
+    console.log(chalk.dim(`yarn cache clean: ${stderr}`));
+  }
+
+  const batchResults = await run(reposUnderTest, async (repo) => {
+    await exec(repo.dir, 'git', ['checkout', '-B', localDependenciesBranch]);
+    writeTestingPackageJson(repo, localConversionMap, options.packageVersion);
+    await exec(
+        repo.dir,
+        'git',
+        ['commit', '-a', '-m', 'testing commit', '--allow-empty']);
+  }, {concurrency: 10});
+  batchResults.failures.forEach(logRepoError);
+
+  return [...batchResults.successes.keys()];
+}
+
+/**
+ * Run `yarn install` to install dependencies in a repo. Note that this creates
+ * a node_modules/ folder & an associated yarn.lock file as side effects.
+ */
+async function installDependencies(reposUnderTest: WorkspaceRepo[]) {
+  const batchResults = await run(reposUnderTest, async (repo) => {
+    const repoDirName = path.basename(repo.dir);
+    const {stderr} = await exec(repo.dir, 'npm', ['install']);
+    if (stderr.length > 0) {
+      console.log(chalk.dim(`${repoDirName}: ${stderr}`));
+    }
+  }, {concurrency: 1});
+
+  batchResults.failures.forEach(logRepoError);
+  return [...batchResults.successes.keys()];
+}
+
+/**
+ * Run `wct --npm` in a repo.
+ */
+async function testRepos(reposUnderTest: WorkspaceRepo[]) {
+  const batchResults = await run(reposUnderTest, async (repo) => {
+    const repoDirName = path.basename(repo.dir);
+    const {stdout, stderr} = await exec(repo.dir, 'wct', ['--npm']);
+    console.log(stdout, stderr);
+    if (stdout.length > 0) {
+      console.log(chalk.dim(`${repoDirName}: ${stdout}`));
+    }
+    if (stderr.length > 0) {
+      console.log(chalk.red(`${repoDirName}: ${stderr}`));
+    }
+  }, {concurrency: 1});
+
+  batchResults.failures.forEach(logRepoError);
+  return [...batchResults.successes.keys()];
+}
+
+/**
+ * Restore the repos to their proper state.
+ */
+async function restoreRepos(reposUnderTest: WorkspaceRepo[]) {
+  const batchResults = await run(reposUnderTest, async (repo) => {
+    await repo.git.destroyAllUncommittedChangesAndFiles();
+    await repo.git.checkout('polymer-modulizer-staging');
+  }, {concurrency: 10});
+
+  batchResults.failures.forEach(logRepoError);
+  return [...batchResults.successes.keys()];
+}
+
+/**
+ * For a given repo, generate a new package.json and write it to disk.
+ */
+function writeTestingPackageJson(
+    repo: WorkspaceRepo,
+    localConversionMap: Map<string, string>,
+    newPackageVersion: string) {
+  const bowerPackageName = path.basename(repo.dir);
+  const bowerJsonPath = path.join(repo.dir, 'bower.json');
+  const bowerJson = readJson(bowerJsonPath);
+  const npmPackageName =
+      lookupNpmPackageName(bowerJsonPath) || bowerPackageName;
+  const packageJson = generatePackageJson(
+      bowerJson, npmPackageName, newPackageVersion, localConversionMap);
+  writeJson(packageJson, repo.dir, 'package.json');
+}
+
+export async function testWorkspace(
+    localConversionMap: Map<string, string>, options: WorkspaceTestSettings) {
+  const allRepos = options.reposToConvert;
+
+  logStep('[1/5]', '🔧', `Preparing Repos...`);
+  const setupSuccesses =
+      await setupRepos(allRepos, localConversionMap, options);
+
+  logStep('[2/5]', '🔧', `Installing Dependencies...`);
+  const installSuccesses = await installDependencies(setupSuccesses);
+
+  logStep('[3/5]', '🔧', `Running Tests...`);
+  const testResults = await testRepos(installSuccesses);
+
+  logStep('[4/5]', '🔧', `Restoring Repos...`);
+  await restoreRepos(allRepos);
+
+  logStep('[5/5]', '🔧', `Tests Complete!`);
+  return testResults;
+}
+
+export async function testWorkspaceInstallOnly(
+    localConversionMap: Map<string, string>, options: WorkspaceTestSettings) {
+  const allRepos = options.reposToConvert;
+
+  logStep('[1/4]', '🔧', `Preparing Repos...`);
+  const setupSuccesses =
+      await setupRepos(allRepos, localConversionMap, options);
+
+  logStep('[2/4]', '🔧', `Installing Dependencies...`);
+  const installResults = await installDependencies(setupSuccesses);
+
+  logStep('[3/4]', '🔧', `Restoring Repos...`);
+  await restoreRepos(allRepos);
+
+  logStep('[4/4]', '🔧', `Tests Complete!`);
+  return installResults;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -93,6 +93,6 @@ export function logRepoError(err: Error, repo: WorkspaceRepo) {
  */
 export function logStep(
     stepNum: number, totalNum: number, emoji: string, msg: string) {
-  const stepInfo = `${stepNum}/${totalNum}`;
+  const stepInfo = `[${stepNum}/${totalNum}]`;
   console.log(`${chalk.dim(stepInfo)} ${emoji}  ${chalk.magenta(msg)}`);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,10 +11,12 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import chalk from 'chalk';
 import {ExecOptions} from 'child_process';
 import {Iterable as IterableX} from 'ix';
 import * as fs from 'mz/fs';
 import * as path from 'path';
+import {WorkspaceRepo} from 'polymer-workspaces';
 
 import {ConvertedDocumentFilePath} from './urls/types';
 
@@ -76,4 +78,19 @@ export async function exec(
     err.cwd = cwd;
     throw err;
   }
+}
+
+/**
+ * Log an error that occurred when performing some task on a workspace repo.
+ */
+export function logRepoError(err: Error, repo: WorkspaceRepo) {
+  const repoDirName = path.basename(repo.dir);
+  console.error(`${repoDirName}: ${err.message}`);
+}
+
+/**
+ * Log a user-facing message about progress through some set of steps.
+ */
+export function logStep(stepNum: string, emoji: string, msg: string) {
+  console.log(`${chalk.dim(stepNum)} ${emoji}  ${chalk.magenta(msg)}`);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,6 +91,8 @@ export function logRepoError(err: Error, repo: WorkspaceRepo) {
 /**
  * Log a user-facing message about progress through some set of steps.
  */
-export function logStep(stepNum: string, emoji: string, msg: string) {
-  console.log(`${chalk.dim(stepNum)} ${emoji}  ${chalk.magenta(msg)}`);
+export function logStep(
+    stepNum: number, totalNum: number, emoji: string, msg: string) {
+  const stepInfo = `${stepNum}/${totalNum}`;
+  console.log(`${chalk.dim(stepInfo)} ${emoji}  ${chalk.magenta(msg)}`);
 }


### PR DESCRIPTION
- `src/test-workspace`: Adds the ability to run tests & `npm install` across repos in a workspace. Packages under conversion are tested against each other (if any are dependencies).
- `src/cli/*`: Presents a menu of actions for the user to do after workspace conversion (right now just "test" & "test (install only)"). Work from #209 to add "push to github" and "publish to npm" will be added here.

<img width="370" alt="screen shot 2017-12-08 at 1 39 43 pm" src="https://user-images.githubusercontent.com/622227/33786259-4606ebe4-dc1d-11e7-8e56-f72cedfe41c8.png">

- Based on https://github.com/Polymer/polymer-workspaces/pull/14, needs to be released to npm before tests will pass. But you can use locally by `npm link`ing that PR.
- Few element tests are passing, but all (or almost all) `npm installs` are working!