### PR TITLE
Add .vscode/launch file for vscode debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ src/gen-ts-types/def/*.js
 
 github-token
 .DS_Store
+debug-output/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/bin/modulizer.js",
+      "cwd": "${workspaceFolder}/fixtures/packages/polymer/source/",
+      "args": [
+        "--npm-name",
+        "@polymer/polymer",
+        "--npm-version",
+        "3.0.0",
+        "--out",
+        "${workspaceFolder}/debug-output",
+        "--force"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a generic .vscode/launch.json configuration for vscode line-by-line debugging. It can be modified to test any specific arguments, but should stay generic within git. 