### PR TITLE
Delete HTML files that are simple wrappers on external scripts

### DIFF
--- a/src/js-module.ts
+++ b/src/js-module.ts
@@ -32,6 +32,7 @@ export interface ConversionResult {
   readonly originalUrl: OriginalDocumentUrl;
   readonly convertedUrl: ConvertedDocumentUrl;
   readonly convertedFilePath: ConvertedDocumentFilePath;
+
   /**
    * Explicitly keep or remove the original file from disk. By default, the
    * original file will be destroyed. If the convertedFilePath matches
@@ -39,9 +40,16 @@ export interface ConversionResult {
    * converted output.
    */
   readonly deleteOriginal?: boolean;
-  readonly output: HtmlFile|JsModule;
-}
 
+  /**
+   * An object describing the converted output of this module, or `undefined`.
+   *
+   * If `undefined`, no new file is created and the original file is deleted
+   * regardless of the value of `deleteOriginal`. This is useful in cases where
+   * there original is an HTML file that only loads an external script.
+   */
+  readonly output: HtmlFile|JsModule|undefined;
+}
 
 export class JsExport {
   /**

--- a/src/project-converter.ts
+++ b/src/project-converter.ts
@@ -73,7 +73,9 @@ export class ProjectConverter {
     console.assert(
         document.kinds.has('html-document'),
         `convertDocument() must be called with an HTML document, but got ${
-            document.kinds}`);
+                                                                           document
+                                                                               .kinds
+                                                                         }`);
     try {
       this.conversionSettings.includes.has(document.url) ?
           this.convertDocumentToJs(document, new Set()) :
@@ -164,7 +166,8 @@ export class ProjectConverter {
    */
   private _handleConversionResult(newModule: ConversionResult): void {
     this.conversionResults.set(newModule.originalUrl, newModule);
-    if (newModule.output.type === 'js-module') {
+    if (newModule.output !== undefined &&
+        newModule.output.type === 'js-module') {
       for (const expr of newModule.output.exportedNamespaceMembers) {
         this.namespacedExports.set(
             expr.oldNamespacedName,
@@ -193,8 +196,10 @@ export class ProjectConverter {
             convertedModule.originalUrl as string as ConvertedDocumentFilePath,
             undefined);
       }
-      results.set(
-          convertedModule.convertedFilePath, convertedModule.output.source);
+      if (convertedModule.output !== undefined) {
+        results.set(
+            convertedModule.convertedFilePath, convertedModule.output.source);
+      }
     }
 
     return results;

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -292,6 +292,25 @@ import './dep.js';
       });
     });
 
+    test('deletes import wrappers', async () => {
+      setSources({
+        'test.html': `
+          <link rel="import" href="./foo.html">
+        `,
+        'foo.html': `
+          <script src="foo.js"></script>
+        `,
+        'foo.js': `
+console.log('foo');
+`,
+      });
+      assertSources(await convert(), {
+        'test.js': `
+import './foo.js';
+`
+      });
+    });
+
     test('converts implicit imports to .js', async () => {
       setSources({
         'test.html': `


### PR DESCRIPTION
Fixes #200 

This is a pretty conservative version of a fix. It only effects files that only have a script tag that points to what would be name of the converted output file. We can extend this to eliminate wrappers that point to other files, but those don't always result in a file being overwritten like this case. We should also probably add detection of overwrites in general.