### PR TITLE
Add import references to a11ySuite in tests

### DIFF
--- a/custom_typings/ast-types.d.ts
+++ b/custom_typings/ast-types.d.ts
@@ -36,6 +36,7 @@ declare module 'ast-types' {
   }
 
   interface VisitorContext {
+    abort(): void;
     traverse(nodePath: NodePath): void;
   }
 
@@ -45,7 +46,10 @@ declare module 'ast-types' {
         (this: VisitorContext, path: NodePath<estree.Program>): void|boolean;
     visitEmptyStatement?
         (this: VisitorContext, path: NodePath<estree.EmptyStatement>):
-            void|boolean;
+      void | boolean;
+    visitCallExpression?
+        (this: VisitorContext, path: NodePath<estree.CallExpression>):
+      void | boolean;
     visitBlockStatement?
         (this: VisitorContext, path: NodePath<estree.BlockStatement>):
             void|boolean;

--- a/fixtures/packages/paper-button/expected/test/paper-button.html
+++ b/fixtures/packages/paper-button/expected/test/paper-button.html
@@ -32,6 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script type="module">
 import '../paper-button.js';
 import { Base } from '../../../@polymer/polymer/polymer.js';
+import { a11ySuite } from '../../../wct-browser-legacy/a11ySuite.js';
 suite('<paper-button>', function() {
   var button;
 

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -19,9 +19,9 @@ import {Workspace} from 'polymer-workspaces';
 
 import {CliOptions} from '../cli';
 import convertWorkspace from '../convert-workspace';
-import { testWorkspace, testWorkspaceInstallOnly } from '../test-workspace';
-import githubPushWorkspace from '../push-workspace';
 import npmPublishWorkspace from '../publish-workspace';
+import githubPushWorkspace from '../push-workspace';
+import {testWorkspace, testWorkspaceInstallOnly} from '../test-workspace';
 import {logStep} from '../util';
 
 const githubTokenMessage = `

--- a/src/passes/add-a11y-suite-if-used.ts
+++ b/src/passes/add-a11y-suite-if-used.ts
@@ -20,6 +20,10 @@ import * as jsc from 'jscodeshift';
 /**
  * Rewrite references in a program from their original names to the local names
  * based on the new named exports system.
+ *
+ * TODO(fks): This standalone A11ySuite handling could be brought into normal
+ * `collectNamespacedReferences()` logic if we added `A11ySuite()` to the known
+ * export graph.
  */
 export function addA11ySuiteIfUsed(
     program: estree.Program, a11ySuiteUrl: string): boolean {

--- a/src/passes/add-a11y-suite-if-used.ts
+++ b/src/passes/add-a11y-suite-if-used.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as astTypes from 'ast-types';
+import {NodePath} from 'ast-types';
+import * as estree from 'estree';
+import * as jsc from 'jscodeshift';
+
+/**
+ * Rewrite references in a program from their original names to the local names
+ * based on the new named exports system.
+ */
+export function addA11ySuiteIfUsed(
+    program: estree.Program, a11ySuiteUrl: string): boolean {
+  let isFound = false;
+  astTypes.visit(program, {
+    visitCallExpression(path: NodePath<estree.CallExpression>) {
+      const callee = path.node.callee as estree.Identifier;
+      const name = callee.name;
+      if (name === 'a11ySuite') {
+        isFound = true;
+        this.abort();
+      }
+      this.traverse(path);
+    }
+  });
+
+  if (!isFound) {
+    return false;
+  }
+
+  program.body.unshift(jsc.importDeclaration(
+      [jsc.importSpecifier(jsc.identifier('a11ySuite'))],
+      jsc.literal(a11ySuiteUrl)));
+  return true;
+}

--- a/src/project-converter.ts
+++ b/src/project-converter.ts
@@ -73,9 +73,7 @@ export class ProjectConverter {
     console.assert(
         document.kinds.has('html-document'),
         `convertDocument() must be called with an HTML document, but got ${
-                                                                           document
-                                                                               .kinds
-                                                                         }`);
+            document.kinds}`);
     try {
       this.conversionSettings.includes.has(document.url) ?
           this.convertDocumentToJs(document, new Set()) :

--- a/src/publish-workspace.ts
+++ b/src/publish-workspace.ts
@@ -14,10 +14,9 @@
 
 import chalk from 'chalk';
 import * as inquirer from 'inquirer';
-import {WorkspaceRepo, publishPackagesToNpm} from 'polymer-workspaces';
+import {publishPackagesToNpm, WorkspaceRepo} from 'polymer-workspaces';
 
 export default async function run(reposToConvert: WorkspaceRepo[]) {
-
   console.log(
       chalk.dim('[1/3] ') + chalk.magenta(`Setting up publish to npm...`));
 

--- a/src/push-workspace.ts
+++ b/src/push-workspace.ts
@@ -14,10 +14,9 @@
 
 import chalk from 'chalk';
 import * as inquirer from 'inquirer';
-import { WorkspaceRepo, startNewBranch, commitChanges, pushChangesToGithub} from 'polymer-workspaces';
+import {commitChanges, pushChangesToGithub, startNewBranch, WorkspaceRepo} from 'polymer-workspaces';
 
 export default async function run(reposToConvert: WorkspaceRepo[]) {
-
   console.log(
       chalk.dim('[1/5] ') + chalk.magenta(`Setting up push to GitHub...`));
   const {commitMessage, branchName, forcePush} = (await inquirer.prompt([
@@ -31,7 +30,8 @@ export default async function run(reposToConvert: WorkspaceRepo[]) {
       type: 'confirm',
       name: 'forcePush',
       message: (args) => {
-        return `force push? (WARNING: This will overwrite any existing "${args.branchName}" branch on GitHub`;
+        return `force push? (WARNING: This will overwrite any existing "${
+            args.branchName}" branch on GitHub`;
       },
       default: false,
     },

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -109,7 +109,7 @@ suite('AnalysisConverter', () => {
 
     function assertSources(
         results: Map<string, string|undefined>,
-        expected: {[path: string]: string | undefined}) {
+        expected: {[path: string]: string|undefined}) {
       for (const [expectedPath, expectedContents] of Object.entries(expected)) {
         assert.isTrue(
             results.has(expectedPath),
@@ -2136,20 +2136,22 @@ console.log("foo");
     });
 
 
-    test('External imported scripts do not get inlined into a module', async () => {
-      setSources({
-        'test.html': `
+    test(
+        'External imported scripts do not get inlined into a module',
+        async () => {
+          setSources({
+            'test.html': `
           <script src='../dep/dep.js'></script>
         `,
-        'bower_components/dep/dep.js': 'console.log("foo");'
-      });
+            'bower_components/dep/dep.js': 'console.log("foo");'
+          });
 
-      assertSources(await convert(), {
-        'test.js': `
+          assertSources(await convert(), {
+            'test.js': `
 import '../dep/dep.js';
 `
-      });
-    });
+          });
+        });
 
     testName = `don't treat all values on a namespace as namespaces themselves`;
     test(testName, async () => {

--- a/src/urls/package-url-handler.ts
+++ b/src/urls/package-url-handler.ts
@@ -88,7 +88,8 @@ export class PackageUrlHandler implements UrlHandler {
         !toUrl.startsWith('./node_modules')) {
       return true;
     }
-    if (fromUrl.startsWith('./node_modules') && toUrl.startsWith('./node_modules')) {
+    if (fromUrl.startsWith('./node_modules') &&
+        toUrl.startsWith('./node_modules')) {
       const fromUrlParts = fromUrl.split('/');
       const toUrlParts = toUrl.split('/');
       if (fromUrlParts[2][0] === '@' && toUrlParts[2][0] === '@') {
@@ -118,6 +119,14 @@ export class PackageUrlHandler implements UrlHandler {
       newUrlPieces[1] = depInfo.npm;
     }
     return ('./' + newUrlPieces.join('/')) as ConvertedDocumentUrl;
+  }
+
+  /**
+   * Create a ConvertedDocumentUrl formatted for the current project layout.
+   * Useful when the converted file location is known ahead of time.
+   */
+  createConvertedUrl(partialUrl: string) {
+    return `./node_modules/${partialUrl}` as ConvertedDocumentUrl;
   }
 
   /**

--- a/src/urls/url-handler.ts
+++ b/src/urls/url-handler.ts
@@ -28,4 +28,5 @@ export interface UrlHandler {
   getPathImportUrl(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       string;
   convertUrl(url: OriginalDocumentUrl): ConvertedDocumentUrl;
+  createConvertedUrl(partialUrl: string): ConvertedDocumentUrl;
 }

--- a/src/urls/workspace-url-handler.ts
+++ b/src/urls/workspace-url-handler.ts
@@ -125,6 +125,13 @@ export class WorkspaceUrlHandler implements UrlHandler {
     return './' + jsUrlPieces.join('/') as ConvertedDocumentUrl;
   }
 
+  /**
+   * Create a ConvertedDocumentUrl formatted for the current project layout.
+   * Useful when the converted file location is known ahead of time.
+   */
+  createConvertedUrl(partialUrl: string) {
+    return `./${partialUrl}` as ConvertedDocumentUrl;
+  }
 
   /**
    * Get the formatted relative import URL between two ConvertedDocumentUrls.


### PR DESCRIPTION
Related to https://github.com/Polymer/web-component-tester/pull/665

`a11ySuite` is now a module, so we need to import references to it directly. This creates an explicit import `a11ySuite` vs. the more convoluted ESM->ESM exporting via the window object.