### PR TITLE
update the dependency map for the latest release

### DIFF
--- a/dependency-map.json
+++ b/dependency-map.json
@@ -1,479 +1,479 @@
 {
   "app-layout": {
     "npm": "@polymer/app-layout",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "app-elements": {
     "npm": "@polymer/app-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "app-localize-behavior": {
     "npm": "@polymer/app-localize-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "app-pouchdb": {
     "npm": "@polymer/app-pouchdb",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "app-route": {
     "npm": "@polymer/app-route",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "app-storage": {
     "npm": "@polymer/app-storage",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-flex-layout": {
     "npm": "@polymer/iron-flex-layout",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-media-query": {
     "npm": "@polymer/iron-media-query",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-resizable-behavior": {
     "npm": "@polymer/iron-resizable-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-scroll-target-behavior": {
     "npm": "@polymer/iron-scroll-target-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "app-layout-templates": {
     "npm": "@polymer/app-layout-templates",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-icon": {
     "npm": "@polymer/iron-icon",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-icons": {
     "npm": "@polymer/iron-icons",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-selector": {
     "npm": "@polymer/iron-selector",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-drawer-panel": {
     "npm": "@polymer/paper-drawer-panel",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-header-panel": {
     "npm": "@polymer/paper-header-panel",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-icon-button": {
     "npm": "@polymer/paper-icon-button",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-item": {
     "npm": "@polymer/paper-item",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-material": {
     "npm": "@polymer/paper-material",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-menu": {
     "npm": "@polymer/paper-menu",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-styles": {
     "npm": "@polymer/paper-styles",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-toggle-button": {
     "npm": "@polymer/paper-toggle-button",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-toolbar": {
     "npm": "@polymer/paper-toolbar",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-ajax": {
     "npm": "@polymer/iron-ajax",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-location": {
     "npm": "@polymer/iron-location",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "chartjs-element": {
     "npm": "@polymer/chartjs-element",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-component-page": {
     "npm": "@polymer/iron-component-page",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "data-elements": {
     "npm": "@polymer/data-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-jsonp-library": {
     "npm": "@polymer/iron-jsonp-library",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "font-roboto": {
     "npm": "@polymer/font-roboto",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "font-roboto-local": {
     "npm": "@polymer/font-roboto-local",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "gold-cc-cvc-input": {
     "npm": "@polymer/gold-cc-cvc-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-form-element-behavior": {
     "npm": "@polymer/iron-form-element-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-input": {
     "npm": "@polymer/paper-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "gold-cc-expiration-input": {
     "npm": "@polymer/gold-cc-expiration-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-a11y-keys-behavior": {
     "npm": "@polymer/iron-a11y-keys-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-validator-behavior": {
     "npm": "@polymer/iron-validator-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-validatable-behavior": {
     "npm": "@polymer/iron-validatable-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "gold-cc-input": {
     "npm": "@polymer/gold-cc-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "gold-elements": {
     "npm": "@polymer/gold-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "gold-email-input": {
     "npm": "@polymer/gold-email-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "gold-phone-input": {
     "npm": "@polymer/gold-phone-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "gold-zip-input": {
     "npm": "@polymer/gold-zip-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-input": {
     "npm": "@polymer/iron-input",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-a11y-announcer": {
     "npm": "@polymer/iron-a11y-announcer",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-a11y-keys": {
     "npm": "@polymer/iron-a11y-keys",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-autogrow-textarea": {
     "npm": "@polymer/iron-autogrow-textarea",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-behaviors": {
     "npm": "@polymer/iron-behaviors",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-behaviors-collection": {
     "npm": "@polymer/iron-behaviors-collection",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-range-behavior": {
     "npm": "@polymer/iron-range-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-overlay-behavior": {
     "npm": "@polymer/iron-overlay-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-scroll-threshold": {
     "npm": "@polymer/iron-scroll-threshold",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-menu-behavior": {
     "npm": "@polymer/iron-menu-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-checked-element-behavior": {
     "npm": "@polymer/iron-checked-element-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-collapse": {
     "npm": "@polymer/iron-collapse",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-doc-viewer": {
     "npm": "@polymer/iron-doc-viewer",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-demo-helpers": {
     "npm": "@polymer/iron-demo-helpers",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "marked-element": {
     "npm": "@polymer/marked-element",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "prism-element": {
     "npm": "@polymer/prism-element",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-button": {
     "npm": "@polymer/paper-button",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-dropdown": {
     "npm": "@polymer/iron-dropdown",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "neon-animation": {
     "npm": "@polymer/neon-animation",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-elements": {
     "npm": "@polymer/iron-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "icon-behaviors-collection": {
     "npm": "@polymer/icon-behaviors-collection",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "icon-input-elements": {
     "npm": "@polymer/icon-input-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-fit-behavior": {
     "npm": "@polymer/iron-fit-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-iconset": {
     "npm": "@polymer/iron-iconset",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-iconset-svg": {
     "npm": "@polymer/iron-iconset-svg",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-image": {
     "npm": "@polymer/iron-image",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-list": {
     "npm": "@polymer/iron-list",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-pages": {
     "npm": "@polymer/iron-pages",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-swipeable-container": {
     "npm": "@polymer/iron-swipeable-container",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-test-helpers": {
     "npm": "@polymer/iron-test-helpers",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-form": {
     "npm": "@polymer/iron-form",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-meta": {
     "npm": "@polymer/iron-meta",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-input-elements": {
     "npm": "@polymer/iron-input-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-label": {
     "npm": "@polymer/iron-label",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-localstorage": {
     "npm": "@polymer/iron-localstorage",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "iron-signals": {
     "npm": "@polymer/iron-signals",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "layout-elements": {
     "npm": "@polymer/layout-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "neon-elements": {
     "npm": "@polymer/neon-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-badge": {
     "npm": "@polymer/paper-badge",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-behaviors": {
     "npm": "@polymer/paper-behaviors",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-ripple": {
     "npm": "@polymer/paper-ripple",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-card": {
     "npm": "@polymer/paper-card",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-checkbox": {
     "npm": "@polymer/paper-checkbox",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-dialog": {
     "npm": "@polymer/paper-dialog",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-dialog-behavior": {
     "npm": "@polymer/paper-dialog-behavior",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-dialog-scrollable": {
     "npm": "@polymer/paper-dialog-scrollable",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-dropdown-menu": {
     "npm": "@polymer/paper-dropdown-menu",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-menu-button": {
     "npm": "@polymer/paper-menu-button",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-elements": {
     "npm": "@polymer/paper-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-input-elements": {
     "npm": "@polymer/paper-input-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-overlay-elements": {
     "npm": "@polymer/paper-overlay-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-ui-elements": {
     "npm": "@polymer/paper-ui-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-fab": {
     "npm": "@polymer/paper-fab",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-listbox": {
     "npm": "@polymer/paper-listbox",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-radio-button": {
     "npm": "@polymer/paper-radio-button",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-radio-group": {
     "npm": "@polymer/paper-radio-group",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-slider": {
     "npm": "@polymer/paper-slider",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-linear-progress": {
     "npm": "@polymer/paper-linear-progress",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-progress": {
     "npm": "@polymer/paper-progress",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-scroll-header-panel": {
     "npm": "@polymer/paper-scroll-header-panel",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-spinner": {
     "npm": "@polymer/paper-spinner",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-swatch-picker": {
     "npm": "@polymer/paper-swatch-picker",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-tabs": {
     "npm": "@polymer/paper-tabs",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-text-field": {
     "npm": "@polymer/paper-text-field",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-toast": {
     "npm": "@polymer/paper-toast",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "paper-tooltip": {
     "npm": "@polymer/paper-tooltip",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "platinum-bluetooth": {
     "npm": "@polymer/platinum-bluetooth",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "platinum-elements": {
     "npm": "@polymer/platinum-elements",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "platinum-https-redirect": {
     "npm": "@polymer/platinum-https-redirect",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "platinum-push-messaging": {
     "npm": "@polymer/platinum-push-messaging",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "platinum-sw": {
     "npm": "@polymer/platinum-sw",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "polymer-starter-kit": {
     "npm": "@polymer/polymer-starter-kit",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "promise-polyfill": {
     "npm": "@polymer/promise-polyfill",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "seed-element": {
     "npm": "@polymer/seed-element",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "performance-benchmark": {
     "npm": "@polymer/performance-benchmark",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "test-fixture": {
     "npm": "@polymer/test-fixture",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "shadycss": {
     "npm": "@webcomponents/shadycss",
@@ -485,7 +485,7 @@
   },
   "polymer": {
     "npm": "@polymer/polymer",
-    "semver": "^3.0.0-pre.1"
+    "semver": "^3.0.0-pre.4"
   },
   "hydrolysis": {
     "npm": "hydrolysis",


### PR DESCRIPTION
We still use this for modulization. Working on a patch to use the being-created version on all packages undergoing conversion.