### PR TITLE
run workspace tests repo-by-repo

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -85,7 +85,7 @@ export async function exec(
  */
 export function logRepoError(err: Error, repo: WorkspaceRepo) {
   const repoDirName = path.basename(repo.dir);
-  console.error(`${repoDirName}: ${err.message}`);
+  console.error(chalk.red(`${repoDirName}: ${err.message}`), err);
 }
 
 /**


### PR DESCRIPTION
When running modulizer on a giant batch of elements, currently we need to wait for the entire batch to complete before getting any error/success messages.