### PR TITLE
report push & publish results

### DIFF
--- a/src/publish-workspace.ts
+++ b/src/publish-workspace.ts
@@ -15,6 +15,7 @@
 import chalk from 'chalk';
 import * as inquirer from 'inquirer';
 import {publishPackagesToNpm, WorkspaceRepo} from 'polymer-workspaces';
+import { logRepoError } from './util';
 
 export default async function run(reposToConvert: WorkspaceRepo[]) {
   console.log(
@@ -52,7 +53,11 @@ export default async function run(reposToConvert: WorkspaceRepo[]) {
   }
 
   console.log(chalk.dim('[2/3] ') + chalk.magenta(`Publishing to npm...`));
-  await publishPackagesToNpm(reposToConvert, publishTag);
+  const publishResults = await publishPackagesToNpm(reposToConvert, publishTag);
+  publishResults.successes.forEach((_result, repo) => {
+    console.log(`  - ${chalk.cyan(repo.dir)}: success!`);
+  });
+  publishResults.failures.forEach(logRepoError);
 
   console.log(chalk.dim('[3/3]') + ' 🎉  ' + chalk.magenta(`Publish Complete!`));
 }

--- a/src/push-workspace.ts
+++ b/src/push-workspace.ts
@@ -15,6 +15,7 @@
 import chalk from 'chalk';
 import * as inquirer from 'inquirer';
 import {commitChanges, pushChangesToGithub, startNewBranch, WorkspaceRepo} from 'polymer-workspaces';
+import { logRepoError } from './util';
 
 export default async function run(reposToConvert: WorkspaceRepo[]) {
   console.log(
@@ -69,7 +70,11 @@ export default async function run(reposToConvert: WorkspaceRepo[]) {
   }
 
   console.log(chalk.dim('[4/5] ') + chalk.magenta(`Pushing to GitHub...`));
-  await pushChangesToGithub(reposToConvert, branchName, forcePush);
+  const publishResults = await pushChangesToGithub(reposToConvert, branchName, forcePush);
+  publishResults.successes.forEach((_result, repo) => {
+    console.log(`  - ${chalk.cyan(repo.dir)}: success!`);
+  });
+  publishResults.failures.forEach(logRepoError);
 
   console.log(chalk.dim('[5/5]') + ' 🎉  ' + chalk.magenta(`Push Complete!`));
 }


### PR DESCRIPTION
Right now they succeed and fail silently. Ultimately these should probably function like our tests, running and logging together serially. But that would require a coordinated change to polymer-workspaces, and right now this is fine.