### PR TITLE
update analyzer to v3.0.0-pre.10, typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,35 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/babel-generator": {
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.1.tgz",
+      "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
+    "@types/babel-traverse": {
+      "version": "6.25.3",
+      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.3.tgz",
+      "integrity": "sha512-4FaulWyA7nrXPkzoukL2VmSpxCnBZwc+MgwZqO30gtHCrtaUXnoxymdYfxzf3CZN80zjtrVzKfLlZ7FPYvrhQQ==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
+    "@types/babel-types": {
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA=="
+    },
+    "@types/babylon": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
+      "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
@@ -43,23 +72,10 @@
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
       "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
     },
-    "@types/escodegen": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@types/escodegen/-/escodegen-0.0.2.tgz",
-      "integrity": "sha1-fOpBqyQukQ6xD2WuGK66RZ1ms18="
-    },
     "@types/esprima": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-2.1.35.tgz",
       "integrity": "sha512-wY9y8ircyGStLJjj9SWos6rjBY5uJmz2dlLUoqC7RYqvEjgRxxFYiyBU6Wu/H7XfuMhLfcJexDZ+hAXA6uHvSw==",
-      "requires": {
-        "@types/estree": "0.0.38"
-      }
-    },
-    "@types/estraverse": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estraverse/-/estraverse-0.0.6.tgz",
-      "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE=",
       "requires": {
         "@types/estree": "0.0.38"
       }
@@ -270,25 +286,18 @@
         "@types/node": "8.0.53"
       }
     },
+    "@types/winston": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.7.tgz",
+      "integrity": "sha512-jNhbkxPtt9xbzvihfA0OavjJbpCIyTDSmwE03BVXgCKcz9lwNsq4cg2wsNkY4Av5eH35ttBArhYtVJa6CIrg2A==",
+      "requires": {
+        "@types/node": "8.0.53"
+      }
+    },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-        }
-      }
     },
     "agent-base": {
       "version": "2.1.1",
@@ -1762,6 +1771,11 @@
       "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1794,11 +1808,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
       "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM="
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "defined": {
       "version": "1.0.0",
@@ -1906,12 +1915,11 @@
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dom5": {
@@ -1920,16 +1928,16 @@
       "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
       "requires": {
         "@types/clone": "0.1.30",
-        "@types/node": "6.0.92",
+        "@types/node": "6.0.96",
         "@types/parse5": "2.2.34",
         "clone": "2.1.1",
         "parse5": "2.2.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.92",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-          "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw=="
+          "version": "6.0.96",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.96.tgz",
+          "integrity": "sha512-fsOOY6tMQ3jCB2wD51XFDmmpgm4wVKkJECdcVRqapbJEa7awJDcr+SaH8toz+4r4KW8YQ3M7ybXMoSDo1QGewA=="
         }
       }
     },
@@ -1938,43 +1946,10 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
-      }
-    },
-    "espree": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
-      "requires": {
-        "acorn": "5.2.1",
-        "acorn-jsx": "3.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
-        }
-      }
-    },
     "esprima": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
@@ -2020,10 +1995,10 @@
         "is-extglob": "1.0.0"
       }
     },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "figures": {
       "version": "2.0.0",
@@ -3178,6 +3153,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
+    "indent": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+      "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3328,6 +3308,11 @@
         "isarray": "1.0.0"
       }
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "ix": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ix/-/ix-2.1.0.tgz",
@@ -3386,9 +3371,9 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
-      "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -3415,15 +3400,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
       "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -3580,6 +3556,24 @@
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "requires": {
         "brace-expansion": "1.1.8"
+      }
+    },
+    "minimatch-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
+      "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
+      "requires": {
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "minimist": {
@@ -3797,26 +3791,6 @@
         "mimic-fn": "1.1.0"
       }
     },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-        }
-      }
-    },
     "orgsync-logger": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/orgsync-logger/-/orgsync-logger-1.4.0.tgz",
@@ -3936,44 +3910,64 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
-    "polymer-analyzer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.3.0.tgz",
-      "integrity": "sha512-mgvLJ7hez52/Iy54GGFVRs9CoO0jXWeS2Iqows5GJpL+KnFiR1afziI2s/5teQcC53vtPUtWba8PEeQHroD5Hw==",
+    "plylog": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
+      "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
       "requires": {
+        "@types/node": "4.2.23",
+        "@types/winston": "2.3.7",
+        "winston": "2.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w=="
+        }
+      }
+    },
+    "polymer-analyzer": {
+      "version": "3.0.0-pre.10",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.10.tgz",
+      "integrity": "sha1-9vCd15PdL0IomsAdoCb8q6ZfGYw=",
+      "requires": {
+        "@types/babel-generator": "6.25.1",
+        "@types/babel-traverse": "6.25.3",
+        "@types/babel-types": "6.25.2",
+        "@types/babylon": "6.16.2",
         "@types/chai-subset": "1.3.1",
         "@types/chalk": "0.4.31",
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
-        "@types/escodegen": "0.0.2",
-        "@types/estraverse": "0.0.6",
-        "@types/estree": "0.0.37",
-        "@types/node": "6.0.92",
+        "@types/minimatch": "3.0.1",
+        "@types/node": "6.0.96",
         "@types/parse5": "2.2.34",
+        "babel-generator": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
         "chalk": "1.1.3",
         "clone": "2.1.1",
         "cssbeautify": "0.3.1",
-        "doctrine": "2.0.0",
+        "doctrine": "2.1.0",
         "dom5": "2.3.0",
-        "escodegen": "1.9.0",
-        "espree": "3.5.2",
-        "estraverse": "4.2.0",
-        "jsonschema": "1.2.0",
+        "indent": "0.0.2",
+        "jsonschema": "1.2.2",
+        "minimatch": "3.0.4",
         "parse5": "2.2.3",
+        "polymer-project-config": "3.8.1",
         "shady-css-parser": "0.1.0",
-        "strip-indent": "2.0.0"
+        "stable": "0.1.6",
+        "strip-indent": "2.0.0",
+        "vscode-uri": "1.0.1"
       },
       "dependencies": {
-        "@types/estree": {
-          "version": "0.0.37",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.37.tgz",
-          "integrity": "sha512-1IT6vNpmU9w18P3v6mN9idv18z5KPVTi4t7+rU9VLnkxo0LCam8IXy/eSVzOaQ1Wpabra2cN3A8K/SliPK/Suw=="
-        },
         "@types/node": {
-          "version": "6.0.92",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-          "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw=="
+          "version": "6.0.96",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.96.tgz",
+          "integrity": "sha512-fsOOY6tMQ3jCB2wD51XFDmmpgm4wVKkJECdcVRqapbJEa7awJDcr+SaH8toz+4r4KW8YQ3M7ybXMoSDo1QGewA=="
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -3997,6 +3991,14 @@
             "supports-color": "2.0.0"
           }
         },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -4012,6 +4014,24 @@
         }
       }
     },
+    "polymer-project-config": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.8.1.tgz",
+      "integrity": "sha512-MLvnM9gexFWg7nynY24eHZG6NLXocmk718sVds/sx2CAJ6iihhC0JMhhOIa6jnad9KQrHyGl/cs3mMRaaub5Fg==",
+      "requires": {
+        "@types/node": "6.0.96",
+        "jsonschema": "1.2.2",
+        "minimatch-all": "1.1.0",
+        "plylog": "0.5.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.96",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.96.tgz",
+          "integrity": "sha512-fsOOY6tMQ3jCB2wD51XFDmmpgm4wVKkJECdcVRqapbJEa7awJDcr+SaH8toz+4r4KW8YQ3M7ybXMoSDo1QGewA=="
+        }
+      }
+    },
     "polymer-workspaces": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/polymer-workspaces/-/polymer-workspaces-2.1.0.tgz",
@@ -4022,11 +4042,6 @@
         "github": "11.0.0",
         "rimraf": "2.6.2"
       }
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "preserve": {
       "version": "0.2.0",
@@ -4479,6 +4494,11 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
       "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "statsd-client": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.2.1.tgz",
@@ -4750,23 +4770,15 @@
         "tslib": "1.8.0"
       }
     },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
     "type-detect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "typical": {
@@ -4795,6 +4807,11 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "vscode-uri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
+      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+    },
     "watchy": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/watchy/-/watchy-0.7.0.tgz",
@@ -4812,6 +4829,31 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "winston": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        }
+      }
     },
     "wordwrap": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jscodeshift": "^0.3.30",
     "mkdirp": "^0.5.1",
     "mz": "^2.6.0",
-    "polymer-analyzer": "~2.3.0",
+    "polymer-analyzer": "^3.0.0-pre.10",
     "polymer-workspaces": "^2.1.0",
     "recast": "^0.12.4",
     "rimraf": "^2.6.1",
@@ -65,7 +65,7 @@
     "dir-compare": "^1.4.0",
     "mocha": "^3.5.3",
     "tslint": "^5.5.0",
-    "typescript": "~2.5.0",
+    "typescript": "^2.6.2",
     "watchy": "^0.7.0"
   }
 }

--- a/src/conversion-settings.ts
+++ b/src/conversion-settings.ts
@@ -15,7 +15,7 @@
 import * as estree from 'estree';
 import {Iterable as IterableX} from 'ix';
 import * as jsc from 'jscodeshift';
-import {Analysis} from 'polymer-analyzer';
+import {Analysis, Analyzer} from 'polymer-analyzer';
 
 export type NpmImportStyle = 'name'|'path';
 
@@ -166,8 +166,8 @@ function getNamespaceNames(analysis: Analysis) {
  * incomplete user-provided options.
  */
 export function createDefaultConversionSettings(
-    analysis: Analysis,
-    options: PartialConversionSettings): ConversionSettings {
+    analyzer: Analyzer, analysis: Analysis, options: PartialConversionSettings):
+    ConversionSettings {
   // Configure "namespaces":
   const namespaces =
       new Set(getNamespaceNames(analysis).concat(options.namespaces || []));
@@ -180,12 +180,15 @@ export function createDefaultConversionSettings(
   const importedFiles =
       IterableX
           .from(analysis.getFeatures({kind: 'import', externalPackages: false}))
-          .map((imp) => imp.url)
+          .filter((imp) => !imp.kinds.has('html-script-back-reference'))
+          .map(
+              (imp) =>
+                  analyzer.urlResolver.relative(imp.url) as string | undefined)
           .filter(
-              (url) =>
-                  !(url.startsWith('bower_components') ||
-                    url.startsWith('node_modules')));
-  const includes = new Set(importedFiles);
+              (url) => !!url &&
+                  (!(url.startsWith('bower_components') ||
+                     url.startsWith('node_modules'))));
+  const includes = new Set(importedFiles as IterableX<string>);
 
   // Configure "referenceExcludes":
   const referenceExcludes = new Set(options.referenceExcludes || [

--- a/src/conversion-settings.ts
+++ b/src/conversion-settings.ts
@@ -185,9 +185,9 @@ export function createDefaultConversionSettings(
               (imp) =>
                   analyzer.urlResolver.relative(imp.url) as string | undefined)
           .filter(
-              (url) => !!url &&
-                  (!(url.startsWith('bower_components') ||
-                     url.startsWith('node_modules'))));
+              (url) => url !== undefined &&
+                  !url.startsWith('bower_components') &&
+                  !url.startsWith('node_modules'));
   const includes = new Set(importedFiles as IterableX<string>);
 
   // Configure "referenceExcludes":

--- a/src/special-casing.ts
+++ b/src/special-casing.ts
@@ -1,3 +1,5 @@
+import {ResolvedUrl} from 'polymer-analyzer';
+
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -13,11 +15,11 @@
  */
 
 // TODO(fks) 07-06-2015: Convert this to a configurable option
-export const polymerFileOverrides: ReadonlyMap<string, string> = new Map([
+export const polymerFileOverrides: ReadonlyMap<ResolvedUrl, string> = new Map([
   // 'lib/utils/boot.html' - This is a special file that overwrites exports
   // and does other things that make less sense in an ESM world.
   [
-    'lib/utils/boot.html',
+    'lib/utils/boot.html' as ResolvedUrl,
     `<script>
   window.JSCompiler_renameProperty = function(prop, obj) { return prop; }
 
@@ -30,7 +32,7 @@ export const polymerFileOverrides: ReadonlyMap<string, string> = new Map([
   // WebComponentsReady event.
   // See: https://github.com/Polymer/polymer-modulizer/issues/111
   [
-    'lib/utils/unresolved.html',
+    'lib/utils/unresolved.html' as ResolvedUrl,
     `
 <script>
 function resolve() {

--- a/src/urls/package-url-handler.ts
+++ b/src/urls/package-url-handler.ts
@@ -60,6 +60,8 @@ export class PackageUrlHandler implements UrlHandler {
   getDocumentUrl(document: Document): OriginalDocumentUrl {
     const relativeUrl =
         this.analyzer.urlResolver.relative(document.url) as string;
+    // If the analyzer URL is outside the current directory, it actually exists
+    // in the child bower_components/ directory.
     if (relativeUrl.startsWith('../')) {
       return 'bower_components/' + relativeUrl.substring(3) as
           OriginalDocumentUrl;

--- a/src/urls/package-url-handler.ts
+++ b/src/urls/package-url-handler.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {Analyzer, Document} from 'polymer-analyzer';
+
 import {lookupDependencyMapping} from '../manifest-converter';
 
 import {ConvertedDocumentFilePath, ConvertedDocumentUrl, OriginalDocumentUrl, PackageType} from './types';
@@ -28,6 +30,7 @@ import {getRelativeUrl} from './util';
 export class PackageUrlHandler implements UrlHandler {
   readonly packageName: string;
   readonly packageType: PackageType;
+  readonly analyzer: Analyzer;
 
   /**
    * Helper function to check if a file URL is internal to the main package
@@ -41,9 +44,28 @@ export class PackageUrlHandler implements UrlHandler {
         !url.startsWith('./node_modules/');
   }
 
-  constructor(packageName: string, packageType: PackageType = 'element') {
+  constructor(
+      analyzer: Analyzer, packageName: string,
+      packageType: PackageType = 'element') {
+    this.analyzer = analyzer;
     this.packageName = packageName;
     this.packageType = packageType;
+  }
+
+  /**
+   * Return a document url property as a OriginalDocumentUrl type.
+   * OriginalDocumentUrl is relative to the project under conversion, unlike
+   * the analyzer's ResolvedUrl, which is absolute to the file system.
+   */
+  getDocumentUrl(document: Document): OriginalDocumentUrl {
+    const relativeUrl =
+        this.analyzer.urlResolver.relative(document.url) as string;
+    if (relativeUrl.startsWith('../')) {
+      return 'bower_components/' + relativeUrl.substring(3) as
+          OriginalDocumentUrl;
+    } else {
+      return relativeUrl as OriginalDocumentUrl;
+    }
   }
 
   /**

--- a/src/urls/url-handler.ts
+++ b/src/urls/url-handler.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {Document} from 'polymer-analyzer/lib/model/document';
+
 import {ConvertedDocumentUrl, OriginalDocumentUrl} from './types';
 
 
@@ -22,6 +24,7 @@ import {ConvertedDocumentUrl, OriginalDocumentUrl} from './types';
  * See PackageUrlHandler, WorkspaceUrlHandler for example implementations.
  */
 export interface UrlHandler {
+  getDocumentUrl(document: Document): OriginalDocumentUrl;
   isImportInternal(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       boolean;
   getNameImportUrl(url: ConvertedDocumentUrl): ConvertedDocumentUrl;

--- a/src/urls/util.ts
+++ b/src/urls/util.ts
@@ -13,7 +13,6 @@
  */
 
 import {posix as path} from 'path';
-import {Document} from 'polymer-analyzer';
 
 import {ConvertedDocumentFilePath, ConvertedDocumentUrl, OriginalDocumentUrl} from './types';
 
@@ -50,13 +49,6 @@ export function getJsModuleConvertedFilePath(originalUrl: OriginalDocumentUrl):
 export function getHtmlDocumentConvertedFilePath(
     originalUrl: OriginalDocumentUrl): ConvertedDocumentFilePath {
   return originalUrl as string as ConvertedDocumentFilePath;
-}
-
-/**
- * Return a document url property as a OriginalDocumentUrl type.
- */
-export function getDocumentUrl(document: Document): OriginalDocumentUrl {
-  return document.url as OriginalDocumentUrl;
 }
 
 /**

--- a/src/urls/workspace-url-handler.ts
+++ b/src/urls/workspace-url-handler.ts
@@ -13,6 +13,7 @@
  */
 
 import * as path from 'path';
+import {Analyzer, Document} from 'polymer-analyzer';
 
 import {lookupDependencyMapping} from '../manifest-converter';
 import {readJson} from '../manifest-converter';
@@ -53,9 +54,21 @@ export function lookupNpmPackageName(bowerJsonPath: string): string|undefined {
 
 export class WorkspaceUrlHandler implements UrlHandler {
   readonly workspaceDir: string;
+  readonly analyzer: Analyzer;
 
-  constructor(workspaceDir: string) {
+  constructor(analyzer: Analyzer, workspaceDir: string) {
     this.workspaceDir = workspaceDir;
+    this.analyzer = analyzer;
+  }
+
+  /**
+   * Return a document url property as a OriginalDocumentUrl type.
+   * OriginalDocumentUrl is relative to the project under conversion, unlike
+   * the analyzer's ResolvedUrl, which is absolute to the file system.
+   */
+  getDocumentUrl(document: Document): OriginalDocumentUrl {
+    return this.analyzer.urlResolver.relative(document.url) as string as
+        OriginalDocumentUrl;
   }
 
   /**


### PR DESCRIPTION
Fixes #306

Background: Polymer Analyzer v3 includes a major change to how urls are handled. Instead of being package-relative, they are now absolute to the file system. polymer-modulizer was built to work with package-relative urls, and gets a lot of benefits from that system over complete absolute 
urls (easier to check against, manipulate, etc). 

This PR updates the existing calls to `getDocumentUrl()` to handle the analyzer's new url format and get all the analyzer updates from the last few months. We now need to keep a reference to the analyzer during conversion itself, but it fits well into our existing concept of a conversion UrlHandler.

Long-term, we could consider doing the work to move to use the analyzer's absolute url format internally as well to take advantage of the analyzer's `relative` URL logic. But at the moment there's no pressing reason to doing so.