### PR TITLE
fix overrides file map url resolution

### DIFF
--- a/src/convert-package.ts
+++ b/src/convert-package.ts
@@ -102,7 +102,7 @@ function configureAnalyzer(options: PackageConversionSettings) {
   for (const [url, contents] of polymerFileOverrides) {
     urlLoader.urlContentsMap.set(urlResolver.resolve(url)!, contents);
     urlLoader.urlContentsMap.set(
-        urlResolver.resolve(`bower_components/polymer/${url}` as ResolvedUrl)!,
+        urlResolver.resolve(`../polymer/${url}` as ResolvedUrl)!,
         contents);
   }
   return new Analyzer({

--- a/src/convert-workspace.ts
+++ b/src/convert-workspace.ts
@@ -13,7 +13,7 @@
  */
 
 import * as path from 'path';
-import {Analyzer, FSUrlLoader, InMemoryOverlayUrlLoader, PackageUrlResolver} from 'polymer-analyzer';
+import {Analyzer, FSUrlLoader, InMemoryOverlayUrlLoader, PackageUrlResolver, ResolvedUrl} from 'polymer-analyzer';
 import {run, WorkspaceRepo} from 'polymer-workspaces';
 
 import {createDefaultConversionSettings, PartialConversionSettings} from './conversion-settings';
@@ -58,7 +58,7 @@ function configureAnalyzer(options: WorkspaceConversionSettings) {
   const urlResolver = new PackageUrlResolver({packageDir: workspaceDir});
   const urlLoader = new InMemoryOverlayUrlLoader(new FSUrlLoader(workspaceDir));
   for (const [url, contents] of polymerFileOverrides) {
-    urlLoader.urlContentsMap.set(urlResolver.resolve(url)!, contents);
+    urlLoader.urlContentsMap.set(urlResolver.resolve(`polymer/${url}` as ResolvedUrl)!, contents);
   }
   return new Analyzer({
     urlLoader,


### PR DESCRIPTION
We have polymer-specific override mappings that were affected by the analyzer 3.0.0 upgrade, but were only just caught when converting actually Polymer & Polymer elements. 