### PR TITLE
Perform atomic package analysis/conversion before modifying files

### DIFF
--- a/fixtures/packages/iron-icon/expected/iron-icon.js
+++ b/fixtures/packages/iron-icon/expected/iron-icon.js
@@ -1,7 +1,8 @@
-import { html, Base } from '../../@polymer/polymer/polymer.js';
+import { Base } from '../../@polymer/polymer/polymer.js';
 import '../../@polymer/iron-meta/iron-meta.js';
 import '../../@polymer/iron-flex-layout/iron-flex-layout.js';
 import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
+import { html } from '../../@polymer/polymer/lib/utils/html-tag.js';
 import { dom } from '../../@polymer/polymer/lib/legacy/polymer.dom.js';
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/boot.js
+++ b/fixtures/packages/polymer/expected/lib/utils/boot.js
@@ -1,4 +1,4 @@
 window.JSCompiler_renameProperty = function(prop, obj) { return prop; }
 
-/** @namespace */
-let Polymer;
+/** @namespace Polymer */
+let __PolymerBootstrap;

--- a/fixtures/packages/polymer/expected/polymer.js
+++ b/fixtures/packages/polymer/expected/polymer.js
@@ -7,7 +7,6 @@ import './lib/elements/dom-if.js';
 import './lib/elements/array-selector.js';
 import './lib/elements/custom-style.js';
 import './lib/legacy/mutable-data-behavior.js';
-import './lib/utils/html-tag.js';
-import { html as html$0 } from './polymer-element.js';
+import { html as html$0 } from './lib/utils/html-tag.js';
 export const Base = LegacyElementMixin(HTMLElement).prototype;
 export { html$0 as html };

--- a/fixtures/packages/polymer/expected/test/smoke/html-tag.html
+++ b/fixtures/packages/polymer/expected/test/smoke/html-tag.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script type="module">
 import { Element } from '../../polymer-element.js';
-import { html as html$0 } from '../../polymer.js';
+import { html as html$0 } from '../../lib/utils/html-tag.js';
 const html = html$0;
 class SuperClass extends Element {
   static get is() {return 'super-class';}

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements.js
@@ -1,6 +1,6 @@
 import './elements-defaults.js';
 import { Polymer } from '../../../../lib/legacy/polymer-fn.js';
-import { html } from '../../../../polymer.js';
+import { html } from '../../../../lib/utils/html-tag.js';
 Polymer({
   importPath: import.meta.url,
 

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/scopes.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/scopes.js
@@ -1,7 +1,7 @@
 import './settings.js';
 import './elements.js';
 import { Polymer } from '../../../../lib/legacy/polymer-fn.js';
-import { html } from '../../../../polymer.js';
+import { html } from '../../../../lib/utils/html-tag.js';
 import { dom } from '../../../../lib/legacy/polymer.dom.js';
 
 Polymer({

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
@@ -1,5 +1,5 @@
 import { Polymer } from '../../../../lib/legacy/polymer-fn.js';
-import { html } from '../../../../polymer.js';
+import { html } from '../../../../lib/utils/html-tag.js';
 const $_documentContainer = document.createElement('div');
 $_documentContainer.setAttribute('style', 'display: none;');
 

--- a/fixtures/packages/polymer/expected/test/unit/attributes-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/attributes-elements.js
@@ -1,5 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/dom-bind-elements1.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-bind-elements1.js
@@ -1,5 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/dom-if-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-if-elements.js
@@ -1,5 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/dom-repeat-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-repeat-elements.js
@@ -1,5 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 import { MutableData } from '../../lib/mixins/mutable-data.js';
 /**
 @license

--- a/fixtures/packages/polymer/expected/test/unit/dynamic-imports/dynamic-element.js
+++ b/fixtures/packages/polymer/expected/test/unit/dynamic-imports/dynamic-element.js
@@ -1,5 +1,6 @@
-import { html } from '../../../polymer.js';
+import '../../../polymer.js';
 import { Polymer } from '../../../lib/legacy/polymer-fn.js';
+import { html } from '../../../lib/utils/html-tag.js';
 import { dom } from '../../../lib/legacy/polymer.dom.js';
 /**
 @license

--- a/fixtures/packages/polymer/expected/test/unit/dynamic-imports/inner-element.js
+++ b/fixtures/packages/polymer/expected/test/unit/dynamic-imports/inner-element.js
@@ -1,5 +1,6 @@
-import { html } from '../../../polymer.js';
+import '../../../polymer.js';
 import { Polymer } from '../../../lib/legacy/polymer-fn.js';
+import { html } from '../../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/events-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/events-elements.js
@@ -1,5 +1,6 @@
-import { Base, html } from '../../polymer.js';
+import { Base } from '../../polymer.js';
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
+import { html } from '../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/gestures-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/gestures-elements.js
@@ -1,5 +1,6 @@
-import { html } from '../../polymer.js';
+import '../../polymer.js';
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
+import { html } from '../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/html-tag.html
+++ b/fixtures/packages/polymer/expected/test/unit/html-tag.html
@@ -17,7 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
   <script type="module">
-import { html } from '../../polymer.js';
+import '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 import { Element } from '../../polymer-element.js';
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 suite('html function', function() {

--- a/fixtures/packages/polymer/expected/test/unit/path-effects-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/path-effects-elements.js
@@ -1,5 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply-import.js
@@ -1,7 +1,7 @@
 import { Element } from '../../polymer-element.js';
 import '../../../../@webcomponents/shadycss/entrypoints/apply-shim.js';
 import '../../lib/elements/custom-style.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/fixtures/packages/polymer/expected/test/unit/property-effects-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/property-effects-elements.js
@@ -1,5 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 import { Element } from '../../polymer-element.js';
 import { MutableDataBehavior } from '../../lib/legacy/mutable-data-behavior.js';
 import { MutableData } from '../../lib/mixins/mutable-data.js';

--- a/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
@@ -1,4 +1,4 @@
-import { html } from '../../../polymer.js';
+import { html } from '../../../lib/utils/html-tag.js';
 import { Element } from '../../../polymer-element.js';
 const $_documentContainer = document.createElement('div');
 $_documentContainer.setAttribute('style', 'display: none;');

--- a/fixtures/packages/polymer/expected/test/unit/templatize-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/templatize-elements.js
@@ -1,7 +1,7 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { Templatize } from '../../lib/utils/templatize.js';
 import { Templatizer } from '../../lib/legacy/templatizer-behavior.js';
-import { html } from '../../polymer.js';
+import { html } from '../../lib/utils/html-tag.js';
 
 /**
 @license

--- a/src/convert-package.ts
+++ b/src/convert-package.ts
@@ -102,8 +102,7 @@ function configureAnalyzer(options: PackageConversionSettings) {
   for (const [url, contents] of polymerFileOverrides) {
     urlLoader.urlContentsMap.set(urlResolver.resolve(url)!, contents);
     urlLoader.urlContentsMap.set(
-        urlResolver.resolve(`../polymer/${url}` as ResolvedUrl)!,
-        contents);
+        urlResolver.resolve(`../polymer/${url}` as ResolvedUrl)!, contents);
   }
   return new Analyzer({
     urlLoader,
@@ -131,13 +130,11 @@ export default async function convert(options: PackageConversionSettings) {
       new PackageUrlHandler(analyzer, options.packageName, options.packageType);
   const conversionSettings =
       getConversionSettings(analyzer, analysis, options, bowerJson);
-  const converter = new ProjectConverter(urlHandler, conversionSettings);
+  const converter =
+      new ProjectConverter(analysis, urlHandler, conversionSettings);
 
-  // Gather all relevent package documents, and run the converter on them!
-  for (const document of getPackageDocuments(
-           urlHandler, analysis, conversionSettings)) {
-    converter.convertDocument(document);
-  }
+  // Convert the package
+  converter.convertPackage(npmPackageName);
 
   // Filter out external results before writing them to disk.
   const results = converter.getResults();

--- a/src/convert-package.ts
+++ b/src/convert-package.ts
@@ -15,7 +15,7 @@
 import * as path from 'path';
 import {Analysis, Analyzer, FSUrlLoader, InMemoryOverlayUrlLoader, PackageUrlResolver, ResolvedUrl} from 'polymer-analyzer';
 
-import {ConversionSettings, createDefaultConversionSettings, PartialConversionSettings} from './conversion-settings';
+import {createDefaultConversionSettings, PartialConversionSettings} from './conversion-settings';
 import {generatePackageJson, readJson, writeJson} from './manifest-converter';
 import {ProjectConverter} from './project-converter';
 import {polymerFileOverrides} from './special-casing';
@@ -75,21 +75,6 @@ function getConversionSettings(
     conversionSettings.includes.add(filename);
   }
   return conversionSettings;
-}
-
-/**
- * Get the relevant documents from a package, to be converted.
- */
-export function getPackageDocuments(
-    urlHandler: PackageUrlHandler,
-    analysis: Analysis,
-    conversionSettings: ConversionSettings) {
-  const htmlDocuments = [...analysis.getFeatures({kind: 'html-document'})];
-  return htmlDocuments.filter((d) => {
-    const documentUrl = urlHandler.getDocumentUrl(d);
-    return PackageUrlHandler.isUrlInternalToPackage(documentUrl) &&
-        !conversionSettings.excludes.has(documentUrl);
-  });
 }
 
 /**

--- a/src/convert-workspace.ts
+++ b/src/convert-workspace.ts
@@ -58,7 +58,8 @@ function configureAnalyzer(options: WorkspaceConversionSettings) {
   const urlResolver = new PackageUrlResolver({packageDir: workspaceDir});
   const urlLoader = new InMemoryOverlayUrlLoader(new FSUrlLoader(workspaceDir));
   for (const [url, contents] of polymerFileOverrides) {
-    urlLoader.urlContentsMap.set(urlResolver.resolve(`polymer/${url}` as ResolvedUrl)!, contents);
+    urlLoader.urlContentsMap.set(
+        urlResolver.resolve(`polymer/${url}` as ResolvedUrl)!, contents);
   }
   return new Analyzer({
     urlLoader,
@@ -80,14 +81,14 @@ export default async function convert(options: WorkspaceConversionSettings):
     Promise<ConversionResultsMap> {
   const analyzer = configureAnalyzer(options);
   const analysis = await analyzer.analyzePackage();
-  const htmlDocuments = [...analysis.getFeatures({kind: 'html-document'})];
   const conversionSettings =
       createDefaultConversionSettings(analyzer, analysis, options);
   const urlHandler = new WorkspaceUrlHandler(analyzer, options.workspaceDir);
-  const converter = new ProjectConverter(urlHandler, conversionSettings);
-  const convertedPackageResults: ConversionResultsMap = new Map();
+  const converter =
+      new ProjectConverter(analysis, urlHandler, conversionSettings);
+  const scannedPackageResults: ConversionResultsMap = new Map();
 
-  // For each repo, convert the relevant HTML documents:
+  // For each repo, convert the full package:
   for (const repo of options.reposToConvert) {
     const repoDirName = path.basename(repo.dir);
     const bowerConfigPath = path.join(repo.dir, 'bower.json');
@@ -95,19 +96,13 @@ export default async function convert(options: WorkspaceConversionSettings):
     if (!npmPackageName) {
       continue;
     }
-    for (const document of htmlDocuments) {
-      const documentUrl = urlHandler.getDocumentUrl(document);
-      if (!documentUrl.startsWith(repoDirName) ||
-          conversionSettings.excludes.has(documentUrl)) {
-        continue;
-      }
-      converter.convertDocument(document);
-    }
-    convertedPackageResults.set(npmPackageName, repo.dir);
+    scannedPackageResults.set(npmPackageName, repo.dir);
+    converter.convertPackage(repoDirName);
   }
 
   // Process & write each conversion result:
-  await writeFileResults(options.workspaceDir, converter.getResults());
+  const results = converter.getResults();
+  await writeFileResults(options.workspaceDir, results);
 
   // Delete files that were explicitly requested to be deleted. Note we apply
   // the glob with each repo as the root directory (e.g. a glob of "types"
@@ -137,5 +132,5 @@ export default async function convert(options: WorkspaceConversionSettings):
   commitResults.failures.forEach(logRepoError);
 
   // Return a map of all packages converted, keyed by npm package name.
-  return convertedPackageResults;
+  return scannedPackageResults;
 }

--- a/src/document-converter.ts
+++ b/src/document-converter.ts
@@ -27,7 +27,7 @@ import * as recast from 'recast';
 
 import {ConversionSettings} from './conversion-settings';
 import {attachCommentsToFirstStatement, canDomModuleBeInlined, collectIdentifierNames, containsWriteToGlobalSettingsObject, createDomNodeInsertStatements, filterClone, findAvailableIdentifier, getCommentsBetween, getMemberPath, getNodePathInProgram, getPathOfAssignmentTo, getSetterName, insertStatementsIntoProgramBody, serializeNode, serializeNodeToTemplateLiteral} from './document-util';
-import {ConversionResult, JsExport} from './js-module';
+import {ConversionResult, JsExport, NamespaceMemberToExport} from './js-module';
 import {addA11ySuiteIfUsed} from './passes/add-a11y-suite-if-used';
 import {removeNamespaceInitializers} from './passes/remove-namespace-initializers';
 import {removeUnnecessaryEventListeners} from './passes/remove-unnecessary-waits';
@@ -128,6 +128,24 @@ interface Edit {
   replacementText: string;
 }
 
+export interface JsModuleScanResult {
+  type: 'js-module';
+  originalUrl: OriginalDocumentUrl;
+  convertedUrl: ConvertedDocumentUrl;
+  exportMigrationRecords: NamespaceMemberToExport[];
+}
+
+export interface DeleteFileScanResult {
+  type: 'delete-file';
+  originalUrl: OriginalDocumentUrl;
+}
+
+export interface HtmlDocumentScanResult {
+  type: 'html-document';
+  originalUrl: OriginalDocumentUrl;
+  convertedUrl: ConvertedDocumentUrl;
+}
+
 /**
  * Convert a module specifier & an optional set of named exports (or '*' to
  * import entire namespace) to a set of ImportDeclaration objects.
@@ -217,7 +235,6 @@ export class DocumentConverter {
   private readonly conversionSettings: ConversionSettings;
   private readonly document: Document;
 
-  private readonly _claimedDomModules = new Set<parse5.ASTNode>();
   constructor(
       document: Document, namespacedExports: Map<string, JsExport>,
       urlHandler: UrlHandler, conversionSettings: ConversionSettings) {
@@ -262,19 +279,14 @@ export class DocumentConverter {
     return isInternalImport && !isModuleImport;
   }
 
-  convertToJsModule(): ConversionResult[] {
-    if (this._isWrapperHTMLDocument) {
-      return [{
-        originalUrl: this.originalUrl,
-        convertedUrl: this.convertedUrl,
-        convertedFilePath: getJsModuleConvertedFilePath(this.originalUrl),
-        deleteOriginal: true,
-        output: undefined,
-      }];
-    }
-
+  /**
+   * Creates a single program from all the JavaScript in the current document.
+   * The standard program result can be used for either scanning or conversion.
+   */
+  private _prepareJsModule() {
     const combinedToplevelStatements = [];
     const convertedHtmlScripts = new Set<Import>();
+    const claimedDomModules = new Set<parse5.ASTNode>();
     let prevScriptNode: parse5.ASTNode|undefined = undefined;
     for (const script of this.document.getFeatures()) {
       let scriptDocument: Document;
@@ -292,7 +304,11 @@ export class DocumentConverter {
       rewriteToplevelThis(scriptProgram);
       // We need to inline templates on a per-script basis, otherwise we run
       // into trouble matching up analyzer AST nodes with our own.
-      this.inlineTemplates(scriptProgram, scriptDocument);
+      const localClaimedDomModules =
+          this.inlineTemplates(scriptProgram, scriptDocument);
+      for (const claimedDomModule of localClaimedDomModules) {
+        claimedDomModules.add(claimedDomModule);
+      }
       if (this.conversionSettings.addImportPath) {
         this.addImportPathsToElements(scriptProgram, scriptDocument);
       }
@@ -312,6 +328,41 @@ export class DocumentConverter {
     const program = jsc.program(combinedToplevelStatements);
     removeUnnecessaryEventListeners(program);
     removeWrappingIIFEs(program);
+
+    this.insertCodeToGenerateHtmlElements(program, claimedDomModules);
+    removeNamespaceInitializers(program, this.conversionSettings.namespaces);
+
+    return {program, convertedHtmlScripts};
+  }
+
+  /**
+   * Scan a document's new interface as a JS Module.
+   */
+  scanJsModule(): DeleteFileScanResult|JsModuleScanResult {
+    if (this._isWrapperHTMLDocument) {
+      return {
+        type: 'delete-file',
+        originalUrl: this.originalUrl,
+      };
+    }
+
+    const {program} = this._prepareJsModule();
+    const {exportMigrationRecords} = rewriteNamespacesAsExports(
+        program, this.document, this.conversionSettings.namespaces);
+
+    return {
+      type: 'js-module',
+      originalUrl: this.originalUrl,
+      convertedUrl: this.convertedUrl,
+      exportMigrationRecords,
+    };
+  }
+
+  /**
+   * Convert a document to a JS Module.
+   */
+  convertJsModule(): ConversionResult[] {
+    const {program, convertedHtmlScripts} = this._prepareJsModule();
     const importedReferences = this.collectNamespacedReferences(program);
     const results: ConversionResult[] = [];
 
@@ -338,10 +389,8 @@ export class DocumentConverter {
         importedReferences.set(newScriptUrl, new Set());
       }
     }
-    this.addJsImports(program, importedReferences);
-    this.insertCodeToGenerateHtmlElements(program);
 
-    removeNamespaceInitializers(program, this.conversionSettings.namespaces);
+    this.addJsImports(program, importedReferences);
     const {localNamespaceNames, namespaceNames, exportMigrationRecords} =
         rewriteNamespacesAsExports(
             program, this.document, this.conversionSettings.namespaces);
@@ -351,7 +400,6 @@ export class DocumentConverter {
     rewriteExcludedReferences(program, this.conversionSettings);
     rewriteReferencesToLocalExports(program, exportMigrationRecords);
     rewriteReferencesToNamespaceMembers(program, allNamespaceNames);
-
     this.warnOnDangerousReferences(program);
 
     const outputProgram =
@@ -362,17 +410,26 @@ export class DocumentConverter {
       convertedUrl: this.convertedUrl,
       convertedFilePath: getJsModuleConvertedFilePath(this.originalUrl),
       deleteOriginal: true,
-      output: {
-        type: 'js-module',
-        source: outputProgram.code + EOL,
-        exportedNamespaceMembers: exportMigrationRecords,
-        es6Exports: new Set(exportMigrationRecords.map((r) => r.es6ExportName))
-      }
+      output: outputProgram.code + EOL
     });
     return results;
   }
 
-  convertAsToplevelHtmlDocument(): ConversionResult {
+  /**
+   * Scan a document as a top-level HTML document.
+   */
+  scanTopLevelHtmlDocument(): HtmlDocumentScanResult {
+    return {
+      type: 'html-document',
+      convertedUrl: this.convertedUrl,
+      originalUrl: this.originalUrl,
+    };
+  }
+
+  /**
+   * Convert a document to a top-level HTML document.
+   */
+  convertTopLevelHtmlDocument(): ConversionResult {
     const htmlDocument = this.document.parsedDocument as ParsedHtmlDocument;
     const p = dom5.predicates;
 
@@ -531,6 +588,7 @@ export class DocumentConverter {
     // Apply edits from bottom to top, so that the offsets stay valid.
     edits.sort(({offsets: [startA]}, {offsets: [startB]}) => startB - startA);
     let contents = this.document.parsedDocument.contents;
+
     for (const {offsets: [start, end], replacementText} of edits) {
       contents =
           contents.slice(0, start) + replacementText + contents.slice(end);
@@ -540,10 +598,21 @@ export class DocumentConverter {
       originalUrl: this.originalUrl,
       convertedUrl: this.convertedUrl,
       convertedFilePath: getHtmlDocumentConvertedFilePath(this.originalUrl),
-      output: {
-        type: 'html-file',
-        source: contents,
-      }
+      output: contents
+    };
+  }
+
+  /**
+   * Create a ConversionResult object to delete the file instead of converting
+   * it.
+   */
+  createDeleteResult(): ConversionResult {
+    return {
+      originalUrl: this.originalUrl,
+      convertedUrl: this.convertedUrl,
+      convertedFilePath: getJsModuleConvertedFilePath(this.originalUrl),
+      deleteOriginal: true,
+      output: undefined,
     };
   }
 
@@ -697,7 +766,8 @@ export class DocumentConverter {
    * code to the top of program that constructs equivalent DOM and insert
    * it into `window.document`.
    */
-  private insertCodeToGenerateHtmlElements(program: Program) {
+  private insertCodeToGenerateHtmlElements(
+      program: Program, claimedDomModules: Set<parse5.ASTNode>) {
     const ast = this.document.parsedDocument.ast as parse5.ASTNode;
     if (ast.childNodes === undefined) {
       return;
@@ -711,12 +781,10 @@ export class DocumentConverter {
       ...body.childNodes!.filter((n: parse5.ASTNode) => n.tagName !== undefined)
     ];
 
-    const genericElements = filterClone(
-        elements,
-        (e) =>
-            !(generatedElementBlacklist.has(e.tagName) ||
-              this._claimedDomModules.has(e)));
-
+    const genericElements = filterClone(elements, (e) => {
+      return !(
+          generatedElementBlacklist.has(e.tagName) || claimedDomModules.has(e));
+    });
     if (genericElements.length === 0) {
       return;
     }
@@ -730,6 +798,7 @@ export class DocumentConverter {
    */
   private inlineTemplates(program: Program, scriptDocument: Document) {
     const elements = scriptDocument.getFeatures({'kind': 'polymer-element'});
+    const claimedDomModules = new Set<parse5.ASTNode>();
 
     for (const element of elements) {
       // This is an analyzer wart. There's no way to avoid getting features
@@ -747,7 +816,7 @@ export class DocumentConverter {
       if (!canDomModuleBeInlined(domModule)) {
         continue;
       }
-      this._claimedDomModules.add(domModule);
+      claimedDomModules.add(domModule);
       const template = dom5.query(domModule, (e) => e.tagName === 'template');
       if (template === null) {
         continue;
@@ -801,6 +870,7 @@ export class DocumentConverter {
             node.type}`);
       }
     }
+    return claimedDomModules;
   }
 
   /**
@@ -873,6 +943,7 @@ export class DocumentConverter {
    */
   private collectNamespacedReferences(program: Program):
       Map<ConvertedDocumentUrl, Set<ImportReference>> {
+    const convertedUrl = this.convertedUrl;
     const namespacedExports = this.namespacedExports;
     const conversionSettings = this.conversionSettings;
     const importedReferences =
@@ -901,7 +972,7 @@ export class DocumentConverter {
           return false;
         }
         const exportOfMember = namespacedExports.get(memberName);
-        if (!exportOfMember) {
+        if (!exportOfMember || exportOfMember.url === convertedUrl) {
           return false;
         }
         // Store the imported reference
@@ -919,8 +990,7 @@ export class DocumentConverter {
         if (assignmentPath) {
           const setterName = getSetterName(memberPath);
           const exportOfMember = namespacedExports.get(setterName);
-          if (!exportOfMember) {
-            // warn about writing to an exported value without a setter?
+          if (!exportOfMember || exportOfMember.url === convertedUrl) {
             this.traverse(path);
             return;
           }
@@ -934,7 +1004,7 @@ export class DocumentConverter {
           return false;
         }
         const exportOfMember = namespacedExports.get(memberName);
-        if (!exportOfMember) {
+        if (!exportOfMember || exportOfMember.url === convertedUrl) {
           this.traverse(path);
           return;
         }

--- a/src/document-converter.ts
+++ b/src/document-converter.ts
@@ -128,6 +128,10 @@ interface Edit {
   replacementText: string;
 }
 
+/**
+ * Contains information about how an existing file should be converted to a new
+ * JS Module. Includes a mapping of its new exports.
+ */
 export interface JsModuleScanResult {
   type: 'js-module';
   originalUrl: OriginalDocumentUrl;
@@ -135,11 +139,19 @@ export interface JsModuleScanResult {
   exportMigrationRecords: NamespaceMemberToExport[];
 }
 
+/**
+ * Contains information that an existing file should be deleted during
+ * conversion.
+ */
 export interface DeleteFileScanResult {
   type: 'delete-file';
   originalUrl: OriginalDocumentUrl;
 }
 
+/**
+ * Contains information that an existing file should be converted as a top-level
+ * HTML file (and not as a new JS module).
+ */
 export interface HtmlDocumentScanResult {
   type: 'html-document';
   originalUrl: OriginalDocumentUrl;
@@ -416,7 +428,9 @@ export class DocumentConverter {
   }
 
   /**
-   * Scan a document as a top-level HTML document.
+   * Scan a document as a top-level HTML document. Top-level HTML documents
+   * have no exports to scan, so this returns a simple object containing
+   * relevant url mapping information.
    */
   scanTopLevelHtmlDocument(): HtmlDocumentScanResult {
     return {

--- a/src/js-module.ts
+++ b/src/js-module.ts
@@ -14,20 +14,6 @@
 
 import {ConvertedDocumentFilePath, ConvertedDocumentUrl, OriginalDocumentUrl} from './urls/types';
 
-
-export interface HtmlFile {
-  readonly type: 'html-file';
-  readonly source: string;
-}
-
-export interface JsModule {
-  readonly type: 'js-module';
-  readonly source: string;
-  readonly exportedNamespaceMembers: ReadonlyArray<NamespaceMemberToExport>;
-  /** Set of exported names. */
-  readonly es6Exports: ReadonlySet<string>;
-}
-
 export interface ConversionResult {
   readonly originalUrl: OriginalDocumentUrl;
   readonly convertedUrl: ConvertedDocumentUrl;
@@ -48,7 +34,7 @@ export interface ConversionResult {
    * regardless of the value of `deleteOriginal`. This is useful in cases where
    * there original is an HTML file that only loads an external script.
    */
-  readonly output: HtmlFile|JsModule|undefined;
+  readonly output: string|undefined;
 }
 
 export class JsExport {

--- a/src/project-converter.ts
+++ b/src/project-converter.ts
@@ -12,11 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Document} from 'polymer-analyzer';
+import {Analysis, Document} from 'polymer-analyzer';
 
 import {ConversionSettings} from './conversion-settings';
 import {DocumentConverter} from './document-converter';
-import {ConversionResult, JsExport} from './js-module';
+import {ConversionResult} from './js-module';
+import {ProjectScanner} from './project-scanner';
 import {ConvertedDocumentFilePath, OriginalDocumentUrl} from './urls/types';
 import {UrlHandler} from './urls/url-handler';
 
@@ -37,30 +38,26 @@ const excludeFromResults = new Set([
  * For best results, only one ProjectConverter instance should be needed, so
  * that it can cache results and avoid duplicate, extraneous document
  * conversions.
- *
- * ProjectConverter is indifferent to the layout of the project, delegating any
- * special URL handling/resolution to the urlHandler provided to the
- * constructor.
  */
 export class ProjectConverter {
-  readonly urlHandler: UrlHandler;
-  readonly conversionSettings: ConversionSettings;
-
-  /**
-   * A cache of all JS Exports by namespace, to map implicit HTML imports to
-   * explicit named JS imports.
-   */
-  readonly namespacedExports = new Map<string, JsExport>();
+  private readonly analysis: Analysis;
+  private readonly urlHandler: UrlHandler;
+  private readonly conversionSettings: ConversionSettings;
+  private readonly scanner: ProjectScanner;
 
   /**
    * A cache of all converted documents. Document conversions should be
    * idempotent, so conversion results can be safely cached.
    */
-  readonly conversionResults = new Map<OriginalDocumentUrl, ConversionResult>();
+  private readonly results = new Map<OriginalDocumentUrl, ConversionResult>();
 
-  constructor(urlHandler: UrlHandler, conversionSettings: ConversionSettings) {
+  constructor(
+      analysis: Analysis, urlHandler: UrlHandler,
+      conversionSettings: ConversionSettings) {
+    this.analysis = analysis;
     this.urlHandler = urlHandler;
     this.conversionSettings = conversionSettings;
+    this.scanner = new ProjectScanner(analysis, urlHandler, conversionSettings);
   }
 
   /**
@@ -68,123 +65,71 @@ export class ProjectConverter {
    * Module or HTML Document) is determined by whether the file is included in
    * conversionSettings.includes.
    */
+  convertPackage(matchPackageName: string) {
+    // First, scan the package (and any of its dependencies)
+    this.scanner.scanPackage(matchPackageName);
+    // Then, convert each document in the given package
+    [...this.analysis.getFeatures({kind: 'html-document'})]
+        .filter((d) => d.isInline === false)
+        .filter((d) => {
+          const documentUrl = this.urlHandler.getDocumentUrl(d);
+          const packageName =
+              this.urlHandler.getOriginalPackageNameForUrl(documentUrl);
+          return packageName === matchPackageName &&
+              !this.conversionSettings.excludes.has(documentUrl);
+        })
+        .forEach((document) => {
+          this.convertDocument(document);
+        });
+  }
+
+  /**
+   * Convert a document. The output format (JS Module or HTML Document) is
+   * dictated by the results of the scanner.
+   */
   convertDocument(document: Document) {
     console.assert(
         document.kinds.has('html-document'),
         `convertDocument() must be called with an HTML document, but got ${
-            document.kinds}`);
-    try {
-      const documentUrl = this.urlHandler.getDocumentUrl(document);
-      this.conversionSettings.includes.has(documentUrl) ?
-          this.convertDocumentToJs(document, new Set()) :
-          this.convertDocumentToHtml(document, new Set());
-    } catch (e) {
-      console.error(`Error in ${document.url}`, e);
-    }
-  }
+      document.kinds}`);
 
-  /**
-   * Check if a document is explicitly excluded or has already been converted
-   * to decide if it should be converted or skipped.
-   */
-  private _shouldConvertDocument(document: Document): boolean {
+    // Note that this should be a quick no-op if this method was called via
+    // convertPackage() (which first scans the entire package) since each
+    // document is only ever scanned once.
+    this.scanner.scanDocument(document);
+    const scanResults = this.scanner.getResults();
     const documentUrl = this.urlHandler.getDocumentUrl(document);
-    return !this.conversionResults.has(documentUrl) &&
-        !this.conversionSettings.excludes.has(documentUrl);
-  }
-
-  /**
-   * Convert document dependencies. Should be called early in the conversion
-   * process so that it can read this document's dependencies' exports.
-   */
-  private _convertDependencies(
-      document: Document, visited: Set<OriginalDocumentUrl>) {
-    for (const htmlImport of DocumentConverter.getAllHtmlImports(document)) {
-      // Ignore excluded or already-converted documents before checking for
-      // cyclical dependencies below.
-      if (!this._shouldConvertDocument(htmlImport.document)) {
-        continue;
-      }
-      // Warn if a cyclical dependency is found.
-      if (visited.has(this.urlHandler.getDocumentUrl(htmlImport.document))) {
-        console.warn(
-            `Cycle in dependency graph found where ` +
-            `${this.urlHandler.getDocumentUrl(document)} imports ${
-                this.urlHandler.getDocumentUrl(htmlImport.document)}.\n` +
-            `    Modulizer does not yet support rewriting references among ` +
-            `cyclic dependencies.`);
-        continue;
-      }
-      // Run a full conversion on the dependency document and its dependencies.
-      this.convertDocumentToJs(htmlImport.document, visited);
+    const scanResult = scanResults.files.get(documentUrl);
+    if (!scanResult) {
+      throw new Error(`File not found during scan: ${documentUrl}`);
     }
-  }
 
-  /**
-   * Convert an HTML document to a JS module. Useful during conversion for
-   * dependencies where the type of result is explictly expected.
-   */
-  convertDocumentToJs(document: Document, visited: Set<OriginalDocumentUrl>) {
-    if (!this._shouldConvertDocument(document)) {
-      return;
-    }
-    visited.add(this.urlHandler.getDocumentUrl(document));
-    this._convertDependencies(document, visited);
     const documentConverter = new DocumentConverter(
         document,
-        this.namespacedExports,
+        scanResults.exports,
         this.urlHandler,
         this.conversionSettings);
-    documentConverter.convertToJsModule().forEach((result) => {
-      this._handleConversionResult(result);
-    });
-  }
-
-  /**
-   * Convert an HTML document without changing the file type (changes imports
-   * and inline scripts to modules as necessary). Useful during conversion for
-   * dependencies where the type of result is explictly expected.
-   */
-  convertDocumentToHtml(document: Document, visited: Set<OriginalDocumentUrl>) {
-    if (!this._shouldConvertDocument(document)) {
-      return;
-    }
-    visited.add(this.urlHandler.getDocumentUrl(document));
-    this._convertDependencies(document, visited);
-    const documentConverter = new DocumentConverter(
-        document,
-        this.namespacedExports,
-        this.urlHandler,
-        this.conversionSettings);
-    const newModule = documentConverter.convertAsToplevelHtmlDocument();
-    this._handleConversionResult(newModule);
-  }
-
-  /**
-   * A private instance method for handling new conversion results, exports,
-   * etc.
-   */
-  private _handleConversionResult(newModule: ConversionResult): void {
-    this.conversionResults.set(newModule.originalUrl, newModule);
-    if (newModule.output !== undefined &&
-        newModule.output.type === 'js-module') {
-      for (const expr of newModule.output.exportedNamespaceMembers) {
-        this.namespacedExports.set(
-            expr.oldNamespacedName,
-            new JsExport(newModule.convertedUrl, expr.es6ExportName));
-      }
+    if (scanResult.type === 'js-module') {
+      documentConverter.convertJsModule().forEach((newModule) => {
+        this.results.set(newModule.originalUrl, newModule);
+      });
+    } else if (scanResult.type === 'html-document') {
+      const newModule = documentConverter.convertTopLevelHtmlDocument();
+      this.results.set(newModule.originalUrl, newModule);
+    } else if (scanResult.type === 'delete-file') {
+      const newModule = documentConverter.createDeleteResult();
+      this.results.set(newModule.originalUrl, newModule);
     }
   }
 
   /**
    * This method collects the results after all documents are converted. It
-   * handles out some broken edge-cases (ex: shadycss) and sets empty map
-   * entries for files to be deleted.
+   * handles any broken edge-cases and sets empty map entries for files to be deleted.
    */
   getResults(): Map<ConvertedDocumentFilePath, string|undefined> {
     const results = new Map<ConvertedDocumentFilePath, string|undefined>();
 
-    for (const convertedModule of this.conversionResults.values()) {
+    for (const convertedModule of this.results.values()) {
       // TODO(fks): This is hacky, ProjectConverter isn't supposed to know about
       //  project layout / file location. Move into URLHandler, potentially make
       //  its own `excludes`-like settings option.
@@ -197,11 +142,9 @@ export class ProjectConverter {
             undefined);
       }
       if (convertedModule.output !== undefined) {
-        results.set(
-            convertedModule.convertedFilePath, convertedModule.output.source);
+        results.set(convertedModule.convertedFilePath, convertedModule.output);
       }
     }
-
     return results;
   }
 }

--- a/src/project-converter.ts
+++ b/src/project-converter.ts
@@ -61,7 +61,7 @@ export class ProjectConverter {
   }
 
   /**
-   * Convert a document and any of its dependencies. The output format (JS
+   * Convert a package and any of its dependencies. The output format (JS
    * Module or HTML Document) is determined by whether the file is included in
    * conversionSettings.includes.
    */

--- a/src/project-scanner.ts
+++ b/src/project-scanner.ts
@@ -68,14 +68,21 @@ export class ProjectScanner {
    * coverted, or otherwise handled by the modulizer.
    */
   getPackageDocuments(matchPackageName: string) {
-    return [...this.analysis.getFeatures({kind: 'html-document'})]
-        .filter((d) => d.isInline === false)
-        .filter((d) => {
+    return [...this.analysis.getFeatures({kind: 'html-document'})].filter(
+        (d) => {
+          // Filter out any inline documents returned by the analyzer
+          if (d.isInline === true) {
+            return false;
+          }
+          // Filter out any excluded documents
           const documentUrl = this.urlHandler.getDocumentUrl(d);
+          if (this.conversionSettings.excludes.has(documentUrl)) {
+            return false;
+          }
+          // Filter out any external documents
           const packageName =
               this.urlHandler.getOriginalPackageNameForUrl(documentUrl);
-          return packageName === matchPackageName &&
-              !this.conversionSettings.excludes.has(documentUrl);
+          return packageName === matchPackageName;
         });
   }
 

--- a/src/project-scanner.ts
+++ b/src/project-scanner.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Analysis, Document} from 'polymer-analyzer';
+
+import {ConversionSettings} from './conversion-settings';
+import {DeleteFileScanResult, DocumentConverter, HtmlDocumentScanResult, JsModuleScanResult} from './document-converter';
+import {JsExport} from './js-module';
+import {OriginalDocumentUrl} from './urls/types';
+import {UrlHandler} from './urls/url-handler';
+
+/**
+ * ProjectScanner provides the top-level interface for scanning packages and
+ * their dependencies. Scanning packages allows us to detect the new ES Module
+ * external interface(s) across a project so that we can properly rewrite and
+ * convert our files.
+ *
+ * For best results, only one ProjectScanner instance should be needed, so
+ * that it can cache results and avoid duplicate, extraneous document
+ * conversions.
+ *
+ * ProjectScanner is indifferent to the layout of the project, delegating any
+ * special URL handling/resolution to the urlHandler provided to the
+ * constructor.
+ */
+export class ProjectScanner {
+  private readonly analysis: Analysis;
+  private readonly urlHandler: UrlHandler;
+  private readonly conversionSettings: ConversionSettings;
+
+  private readonly scannedPackages = new Set<string>();
+
+  /**
+   * All JS Exports registered by namespaced identifier, to map implicit HTML
+   * imports to explicit named JS imports.
+   */
+  private readonly namespacedExports = new Map<string, JsExport>();
+
+  /**
+   * All Scan Results registered by document URL, so that the conversion process
+   * knows how to treat each file.
+   */
+  private readonly results = new Map<
+      OriginalDocumentUrl,
+      JsModuleScanResult|DeleteFileScanResult|HtmlDocumentScanResult>();
+
+  constructor(
+      analysis: Analysis, urlHandler: UrlHandler,
+      conversionSettings: ConversionSettings) {
+    this.analysis = analysis;
+    this.urlHandler = urlHandler;
+    this.conversionSettings = conversionSettings;
+  }
+
+  /**
+   * Scan a document and any of its dependency packages for their new interface.
+   */
+  scanPackage(matchPackageName: string) {
+    if (this.scannedPackages.has(matchPackageName)) {
+      return;
+    }
+    // Add this package to our cache so that it won't get double scanned.
+    this.scannedPackages.add(matchPackageName);
+    // Gather all relevent package documents, and run the scanner on them.
+    [...this.analysis.getFeatures({kind: 'html-document'})]
+        .filter((d) => d.isInline === false)
+        .filter((d) => {
+          const documentUrl = this.urlHandler.getDocumentUrl(d);
+          const packageName =
+              this.urlHandler.getOriginalPackageNameForUrl(documentUrl);
+          return packageName === matchPackageName;
+        })
+        .forEach((document) => {
+          this.scanDocument(document);
+        });
+  }
+
+  /**
+   * Scan a document and any of its dependency packages. The scan document
+   * format (JS Module or HTML Document) is determined by whether the file is
+   * included in conversionSettings.includes.
+   */
+  scanDocument(document: Document, forceJs = false) {
+    console.assert(
+        document.kinds.has('html-document'),
+        `scanDocument() must be called with an HTML document, but got ${
+            document.kinds}`);
+
+    if (!this._shouldScanDocument(document)) {
+      return;
+    }
+
+    const documentUrl = this.urlHandler.getDocumentUrl(document);
+    const documentConverter = new DocumentConverter(
+        document,
+        this.namespacedExports,
+        this.urlHandler,
+        this.conversionSettings);
+    let scanResult: JsModuleScanResult|HtmlDocumentScanResult|
+        DeleteFileScanResult;
+    try {
+      scanResult =
+          (forceJs || this.conversionSettings.includes.has(documentUrl)) ?
+          documentConverter.scanJsModule() :
+          documentConverter.scanTopLevelHtmlDocument();
+    } catch (e) {
+      console.error(`Error in ${document.url}`, e);
+      return;
+    }
+    this.results.set(scanResult.originalUrl, scanResult);
+    this._scanDependencies(document);
+    if (scanResult.type === 'js-module') {
+      for (const expr of scanResult.exportMigrationRecords) {
+        if (!this.namespacedExports.has(expr.oldNamespacedName)) {
+          this.namespacedExports.set(
+              expr.oldNamespacedName,
+              new JsExport(scanResult.convertedUrl, expr.es6ExportName));
+        }
+      }
+    }
+  }
+
+  /**
+   * Check if a document is explicitly excluded or has already been scanned
+   * to decide if it should be skipped.
+   */
+  private _shouldScanDocument(document: Document): boolean {
+    const documentUrl = this.urlHandler.getDocumentUrl(document);
+    return !this.results.has(documentUrl) &&
+        !this.conversionSettings.excludes.has(documentUrl);
+  }
+
+  /**
+   * Scan document dependencies. If a dependency is external to this package,
+   * scan the entire external package.
+   */
+  private _scanDependencies(document: Document) {
+    const documentUrl = this.urlHandler.getDocumentUrl(document);
+    const packageName =
+        this.urlHandler.getOriginalPackageNameForUrl(documentUrl);
+    for (const htmlImport of DocumentConverter.getAllHtmlImports(document)) {
+      const importDocumentUrl = this.urlHandler.getDocumentUrl(<any>htmlImport);
+      const importPackageName =
+          this.urlHandler.getOriginalPackageNameForUrl(importDocumentUrl);
+
+      if (importPackageName === packageName) {
+        this.scanDocument(htmlImport.document, true);
+      } else {
+        this.scanPackage(importPackageName);
+      }
+    }
+  }
+
+  getResults() {
+    return {
+      files: this.results,
+      exports: this.namespacedExports,
+    };
+  }
+}

--- a/src/special-casing.ts
+++ b/src/special-casing.ts
@@ -23,8 +23,8 @@ export const polymerFileOverrides: ReadonlyMap<ResolvedUrl, string> = new Map([
     `<script>
   window.JSCompiler_renameProperty = function(prop, obj) { return prop; }
 
-  /** @namespace */
-  let Polymer;
+  /** @namespace Polymer */
+  let __PolymerBootstrap;
 </script>`
   ],
 

--- a/src/test/fixtures/fixtures_test.ts
+++ b/src/test/fixtures/fixtures_test.ts
@@ -137,7 +137,6 @@ suite('Fixtures', () => {
 
         // 1. Check stderr output that no (unexpected) errors were emitted.
         assert.equal(output.stderr, (fixtureTestConfig.stderr || ''));
-
         // 2. Compare the generated output to the expected conversion.
         //    Output the diff & fail if any differences are encountered.
         const diffResult =

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -19,7 +19,6 @@ import {EOL} from 'os';
 import {Analyzer, InMemoryOverlayUrlLoader} from 'polymer-analyzer';
 
 import {createDefaultConversionSettings, PartialConversionSettings} from '../../conversion-settings';
-import {getPackageDocuments} from '../../convert-package';
 import {getMemberPath} from '../../document-util';
 import {ProjectConverter} from '../../project-converter';
 import {PackageUrlHandler} from '../../urls/package-url-handler';
@@ -94,11 +93,7 @@ suite('AnalysisConverter', () => {
           await new ProjectConverter(analysis, urlHandler, conversionSettings);
       // Gather all relevent package documents, and run the converter!
       const stopIntercepting = interceptWarnings();
-      for (const doc of getPackageDocuments(
-               urlHandler, analysis, conversionSettings)) {
-        // converter.scanDocument(doc);
-        converter.convertDocument(doc);
-      }
+      converter.convertPackage(packageName);
       // Assert warnings matched expected.
       const warnings = stopIntercepting();
       assert.deepEqual(

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -22,7 +22,6 @@ import {createDefaultConversionSettings, PartialConversionSettings} from '../../
 import {getPackageDocuments} from '../../convert-package';
 import {getMemberPath} from '../../document-util';
 import {ProjectConverter} from '../../project-converter';
-// import {ProjectScanner} from '../../project-scanner';
 import {PackageUrlHandler} from '../../urls/package-url-handler';
 import {PackageType} from '../../urls/types';
 
@@ -91,8 +90,6 @@ suite('AnalysisConverter', () => {
       // Setup ProjectScanner, use PackageUrlHandler for easy setup.
       const urlHandler =
           new PackageUrlHandler(analyzer, packageName, packageType);
-      // const converter =
-      // await new ProjectScanner(analysis, urlHandler, conversionSettings);
       const converter =
           await new ProjectConverter(analysis, urlHandler, conversionSettings);
       // Gather all relevent package documents, and run the converter!

--- a/src/urls/package-url-handler.ts
+++ b/src/urls/package-url-handler.ts
@@ -71,26 +71,17 @@ export class PackageUrlHandler implements UrlHandler {
   }
 
   /**
-   * Get the bower package name from an OriginalDocumentUrl and check our
-   * dependency map for the matching npm package name match. If URL is internal
-   * (no bower package name in URL) return the current package name.
+   * Get the name of the package where a file lives, based on it's URL. For a
+   * workspace, we read the Bower package name from the bower.json of every
+   * repo, and then check dependency map to get the new NPM name for that
+   * package.
    */
-  getPackageNameForUrl(url: OriginalDocumentUrl) {
-    // If url contains no directories it must be internal. Explicitly check
-    // `basePackageName` here since it is needed below.
-    const urlParts = url.split('/');
-    const basePackageName = urlParts[1] as (string | undefined);
-    if (!basePackageName || PackageUrlHandler.isUrlInternalToPackage(url)) {
+  getOriginalPackageNameForUrl(url: OriginalDocumentUrl): string {
+    if (url.startsWith('../')) {
+      return url.split('/')[1];
+    } else {
       return this.packageName;
     }
-    // For a a single package layout, the Bower package name is included in
-    // the URL. ie: bower_components/PACKAGE_NAME/...
-    // Check the dependency map to get the new NPM name for the package.
-    const depInfo = lookupDependencyMapping(basePackageName);
-    if (!depInfo) {
-      return basePackageName;
-    }
-    return depInfo.npm;
   }
 
   /**

--- a/src/urls/package-url-handler.ts
+++ b/src/urls/package-url-handler.ts
@@ -77,7 +77,7 @@ export class PackageUrlHandler implements UrlHandler {
    * package.
    */
   getOriginalPackageNameForUrl(url: OriginalDocumentUrl): string {
-    if (url.startsWith('../')) {
+    if (url.startsWith('bower_components/')) {
       return url.split('/')[1];
     } else {
       return this.packageName;

--- a/src/urls/url-handler.ts
+++ b/src/urls/url-handler.ts
@@ -27,6 +27,7 @@ export interface UrlHandler {
   getDocumentUrl(document: Document): OriginalDocumentUrl;
   isImportInternal(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       boolean;
+  getOriginalPackageNameForUrl(url: OriginalDocumentUrl): string;
   getNameImportUrl(url: ConvertedDocumentUrl): ConvertedDocumentUrl;
   getPathImportUrl(fromUrl: ConvertedDocumentUrl, toUrl: ConvertedDocumentUrl):
       string;

--- a/src/urls/workspace-url-handler.ts
+++ b/src/urls/workspace-url-handler.ts
@@ -12,7 +12,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as path from 'path';
 import {Analyzer, Document} from 'polymer-analyzer';
 
 import {lookupDependencyMapping} from '../manifest-converter';
@@ -72,35 +71,13 @@ export class WorkspaceUrlHandler implements UrlHandler {
   }
 
   /**
-   * Cache the npm package name found for each
-   */
-  packageNameCache = new Map<string, string>();
-
-  /**
    * Get the name of the package where a file lives, based on it's URL. For a
    * workspace, we read the Bower package name from the bower.json of every
    * repo, and then check dependency map to get the new NPM name for that
    * package.
    */
-  getPackageNameForUrl(url: OriginalDocumentUrl) {
-    const basePackageDir = url.split('/')[0];
-    const cachedPackageName = this.packageNameCache.get(basePackageDir);
-    if (cachedPackageName) {
-      return cachedPackageName;
-    }
-    const packageName = this._getPackageNameForUrl(url);
-    this.packageNameCache.set(basePackageDir, packageName);
-    return packageName;
-  }
-
-  /**
-   * Get the name of the package where a file lives, based on it's URL.
-   */
-  _getPackageNameForUrl(url: OriginalDocumentUrl) {
-    const packageDirName = url.split('/')[0];
-    const bowerPath =
-        path.join(this.workspaceDir, packageDirName, 'bower.json');
-    return lookupNpmPackageName(bowerPath) || packageDirName;
+  getOriginalPackageNameForUrl(url: OriginalDocumentUrl): string {
+    return url.split('/')[0];
   }
 
   /**


### PR DESCRIPTION
## What is this?

This PR represents a big change to how we run conversions across files and packages. The main goals were to:
1. Perform repeatable package conversions that aren't dependent on how any one file is imported (current logic runs conversions file by file in a way that affects how a package is converted)
2. Package conversion should be represented by some serializable data that could be written to file and cached with each package. Future work will allow the modulizer to read this file instead of performing independent conversions of each dependency.
3. Unintentionally, making those changes involved splitting the current conversion process into two processes, which ~forced~ allowed us to also fix support for cyclical imports, which currently break the modulizer.

## Implementation tl;dr

- Packages are now converted as entire packages, instead of document-by-document. 
- This PR adds a new scanning stage into the conversion process. Before any package is converted to ESM, it's interface and the interface of all dependency packages are scanned.
- Scanning is a form of static analysis that doesn't block on cyclical imports.
- Splitting out this step of the conversion simplifies the conversion logic overall.


