### PR TITLE
Scan exports by package, resolve export conflicts by project

### DIFF
--- a/src/package-scanner.ts
+++ b/src/package-scanner.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Analysis, Document} from 'polymer-analyzer';
+
+import {ConversionSettings} from './conversion-settings';
+import {DeleteFileScanResult, DocumentConverter, HtmlDocumentScanResult, JsModuleScanResult} from './document-converter';
+import {JsExport} from './js-module';
+import {OriginalDocumentUrl} from './urls/types';
+import {UrlHandler} from './urls/url-handler';
+
+export interface PackageScanResult {
+  files:
+      Map<OriginalDocumentUrl,
+          JsModuleScanResult|DeleteFileScanResult|HtmlDocumentScanResult>;
+  exports: Map<string, JsExport>;
+}
+
+/**
+ * PackageScanner provides the top-level interface for scanning any single
+ * package. Scanning packages allows us to detect the new ES Module
+ * external interface(s) across a project so that we can properly rewrite and
+ * convert our files.
+ */
+export class PackageScanner {
+  private readonly packageName: string;
+  private readonly analysis: Analysis;
+  private readonly urlHandler: UrlHandler;
+  private readonly conversionSettings: ConversionSettings;
+
+  /**
+   * A set of all external dependencies (by name) actually detected as JS
+   * imported by this package.
+   */
+  readonly externalDependencies = new Set<string>();
+
+  /**
+   * All JS Exports for a single package registered by namespaced identifier,
+   * to map implicit HTML imports to explicit named JS imports.
+   */
+  private readonly namespacedExports = new Map<string, JsExport>();
+
+  /**
+   * All Scan Results for a single package registered by document URL, so that
+   * the conversion process knows how to treat each file.
+   */
+  private readonly results = new Map<
+      OriginalDocumentUrl,
+      JsModuleScanResult|DeleteFileScanResult|HtmlDocumentScanResult>();
+
+  constructor(
+      packageName: string, analysis: Analysis, urlHandler: UrlHandler,
+      conversionSettings: ConversionSettings) {
+    this.packageName = packageName;
+    this.analysis = analysis;
+    this.urlHandler = urlHandler;
+    this.conversionSettings = conversionSettings;
+  }
+
+  /**
+   * Scan a package.
+   */
+  scanPackage(): PackageScanResult {
+    // Add this package to our cache so that it won't get double scanned.
+    // Gather all relevent package documents, and run the scanner on them.
+    for (const document of this.getPackageDocuments()) {
+      this.scanDocument(document);
+    }
+
+    return this.getResults();
+  }
+
+  /**
+   * Get all relevant HTML documents from a package that should be scanned,
+   * coverted, or otherwise handled by the modulizer.
+   */
+  getPackageDocuments() {
+    return [
+      ...this.analysis.getFeatures(
+          {kind: 'html-document', externalPackages: true})
+    ].filter((d) => {
+      // Filter out any inline documents returned by the analyzer
+      if (d.isInline === true) {
+        return false;
+      }
+      // Filter out any excluded documents
+      const documentUrl = this.urlHandler.getDocumentUrl(d);
+      if (this.conversionSettings.excludes.has(documentUrl)) {
+        return false;
+      }
+      // Filter out any external documents
+      const packageName =
+          this.urlHandler.getOriginalPackageNameForUrl(documentUrl);
+      return packageName === this.packageName;
+    });
+  }
+
+  /**
+   * Return the results of the package scan.
+   */
+  getResults(): PackageScanResult {
+    return {
+      files: this.results,
+      exports: this.namespacedExports,
+    };
+  }
+
+  /**
+   * Scan a document and any of its dependency packages. The scan document
+   * format (JS Module or HTML Document) is determined by whether the file is
+   * included in conversionSettings.includes.
+   */
+  private scanDocument(document: Document, forceJs = false) {
+    console.assert(
+        document.kinds.has('html-document'),
+        `scanDocument() must be called with an HTML document, but got ${
+            document.kinds}`);
+    if (!this._shouldScanDocument(document)) {
+      return;
+    }
+
+    const documentUrl = this.urlHandler.getDocumentUrl(document);
+    const documentConverter = new DocumentConverter(
+        document, this.urlHandler, this.conversionSettings);
+    let scanResult: JsModuleScanResult|HtmlDocumentScanResult|
+        DeleteFileScanResult;
+    try {
+      scanResult =
+          (forceJs || this.conversionSettings.includes.has(documentUrl)) ?
+          documentConverter.scanJsModule() :
+          documentConverter.scanTopLevelHtmlDocument();
+    } catch (e) {
+      console.error(`Error in ${document.url}`, e);
+      return;
+    }
+    this.results.set(scanResult.originalUrl, scanResult);
+    this._scanDependencies(document);
+    if (scanResult.type === 'js-module') {
+      for (const expr of scanResult.exportMigrationRecords) {
+        if (!this.namespacedExports.has(expr.oldNamespacedName)) {
+          this.namespacedExports.set(
+              expr.oldNamespacedName,
+              new JsExport(scanResult.convertedUrl, expr.es6ExportName));
+        }
+      }
+    }
+  }
+
+  /**
+   * Check if a document is explicitly excluded or has already been scanned
+   * to decide if it should be skipped.
+   */
+  private _shouldScanDocument(document: Document): boolean {
+    const documentUrl = this.urlHandler.getDocumentUrl(document);
+    return !this.results.has(documentUrl) &&
+        !this.conversionSettings.excludes.has(documentUrl);
+  }
+
+  /**
+   * Scan dependency files of a document. If a file is external to this package,
+   * add that dependency to the externalDependencies set to be scanned
+   * seperately.
+   */
+  private _scanDependencies(document: Document) {
+    const documentUrl = this.urlHandler.getDocumentUrl(document);
+    const packageName =
+        this.urlHandler.getOriginalPackageNameForUrl(documentUrl);
+
+    for (const htmlImport of DocumentConverter.getAllHtmlImports(document)) {
+      const importDocumentUrl = this.urlHandler.getDocumentUrl(<any>htmlImport);
+      const importPackageName =
+          this.urlHandler.getOriginalPackageNameForUrl(importDocumentUrl);
+
+      if (importPackageName === packageName) {
+        this.scanDocument(htmlImport.document, true);
+      } else {
+        this.externalDependencies.add(importPackageName);
+      }
+    }
+  }
+}

--- a/src/project-converter.ts
+++ b/src/project-converter.ts
@@ -63,29 +63,33 @@ export class ProjectConverter {
    * Module or HTML Document) is determined by whether the file is included in
    * conversionSettings.includes.
    */
-  convertPackage(matchPackageName: string) {
+  convertPackage(packageName: string) {
     // First, scan the package (and any of its dependencies)
-    this.scanner.scanPackage(matchPackageName);
+    this.scanner.scanPackage(packageName);
     // Then, convert each document in the given package
-    for (const document of this.scanner.getPackageDocuments(matchPackageName)) {
+    for (const document of this.scanner.getPackageDocuments(packageName)) {
       this.convertDocument(document);
     }
+  }
+
+  /**
+   * Get a package manifest (a serializable version of the scanner results) for
+   * a package.
+   */
+  getPackageManifest(packageName: string) {
+    return this.scanner.getPackageManifest(packageName);
   }
 
   /**
    * Convert a document. The output format (JS Module or HTML Document) is
    * dictated by the results of the scanner.
    */
-  convertDocument(document: Document) {
+  private convertDocument(document: Document) {
     console.assert(
         document.kinds.has('html-document'),
         `convertDocument() must be called with an HTML document, but got ${
             document.kinds}`);
 
-    // Note that this should be a quick no-op if this method was called via
-    // convertPackage() (which first scans the entire package) since each
-    // document is only ever scanned once.
-    this.scanner.scanDocument(document);
     const scanResults = this.scanner.getResults();
     const documentUrl = this.urlHandler.getDocumentUrl(document);
     const scanResult = scanResults.files.get(documentUrl);
@@ -94,16 +98,15 @@ export class ProjectConverter {
     }
 
     const documentConverter = new DocumentConverter(
-        document,
-        scanResults.exports,
-        this.urlHandler,
-        this.conversionSettings);
+        document, this.urlHandler, this.conversionSettings);
     if (scanResult.type === 'js-module') {
-      documentConverter.convertJsModule().forEach((newModule) => {
-        this.results.set(newModule.originalUrl, newModule);
-      });
+      documentConverter.convertJsModule(scanResults.exports)
+          .forEach((newModule) => {
+            this.results.set(newModule.originalUrl, newModule);
+          });
     } else if (scanResult.type === 'html-document') {
-      const newModule = documentConverter.convertTopLevelHtmlDocument();
+      const newModule =
+          documentConverter.convertTopLevelHtmlDocument(scanResults.exports);
       this.results.set(newModule.originalUrl, newModule);
     } else if (scanResult.type === 'delete-file') {
       const newModule = documentConverter.createDeleteResult();
@@ -123,7 +126,7 @@ export class ProjectConverter {
       // TODO(fks): This is hacky, ProjectConverter isn't supposed to know about
       //  project layout / file location. Move into URLHandler, potentially make
       //  its own `excludes`-like settings option.
-      if (excludeFromResults.has(convertedModule.originalUrl)) {
+      if (excludeFromResults.has(convertedModule.convertedFilePath)) {
         continue;
       }
       if (convertedModule.deleteOriginal) {


### PR DESCRIPTION
Still trying to unblock package manifest reading/writing, but unfortunately lots of little known issues are blocking us. This PR gets us 99% there, up to the writing of the created manifest as a per-package scan artifact. Blocking the manifest writing is:

- **package mode**: Now that we're scanning packages instead of specific documents, the current project-level `includes` file set no longer works. We have a workaround for workspace mode, but we either need to bring that same workaround to package mode, remove package mode, or create a permanent fix now based on bower.json.
- **all modes:** files URLs are project-relative. We need to add package-relative URL logic so that URLs written in manifests are all package-relative. We currently don't have an idea of "package-relative" creation, or conversion from a bower- or npm-world URL.

I'm creating this PR as a checkpoint, then planning to fix these two blocking issues, then finally connecting the manifest to the "writeJSON" logic.
