### PR TITLE
Convert package.json's main field

### DIFF
--- a/fixtures/packages/polymer/expected/package.json
+++ b/fixtures/packages/polymer/expected/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/Polymer/polymer",
   "name": "@polymer/polymer",
   "version": "3.0.0",
-  "main": "polymer.html",
+  "main": "polymer.js",
   "directories": {
     "doc": "docs",
     "test": "test"

--- a/src/manifest-converter.ts
+++ b/src/manifest-converter.ts
@@ -183,6 +183,8 @@ export function generatePackageJson(
           `so this package will not be directly importable by name. ` +
           `Manually update main in your bower.json or package.json to fix.`);
     }
+  } else {
+    packageJson.main = replaceHtmlExtensionIfFound(packageJson.main);
   }
 
   if (!packageJson.author &&


### PR DESCRIPTION
Converts package.json's main field if it exists.

Other approaches I've considered:
* Convert it only if it is in the bower.json's mains
  * I felt this overlapped a lot with this use case
  * simple to implement
* somehow figure out if the file has already been converted by the modulizer and then change it
  * Not sure where that happens / if there is a manifest of changed files
  * Seems like a larger structural change