### PR TITLE
add ability to map custom bower->npm dependencies

### DIFF
--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -18,7 +18,10 @@ import * as semver from 'semver';
 
 import {CliOptions} from '../cli';
 import convertPackage from '../convert-package';
+import {saveDependencyMapping} from '../package-manifest';
 import {exec, logStep} from '../util';
+
+import {parseDependencyMappingInput} from './util';
 
 export default async function run(options: CliOptions) {
   const inDir = path.resolve(options.in || process.cwd());
@@ -32,6 +35,17 @@ export default async function run(options: CliOptions) {
         `Git repo is dirty. Check all changes in to source control and ` +
         `then try again.`);
     process.exit(1);
+  }
+
+  for (const rawMapping of options['dependency-mapping']) {
+    try {
+      const [bowerName, npmName, npmSemver] =
+          parseDependencyMappingInput(rawMapping);
+      saveDependencyMapping(bowerName, npmName, npmSemver);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
   }
 
   // TODO: each file is not always needed, refactor to optimize loading

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -19,10 +19,13 @@ import {Workspace} from 'polymer-workspaces';
 
 import {CliOptions} from '../cli';
 import convertWorkspace from '../convert-workspace';
+import {saveDependencyMapping} from '../package-manifest';
 import npmPublishWorkspace from '../publish-workspace';
 import githubPushWorkspace from '../push-workspace';
 import {testWorkspace, testWorkspaceInstallOnly} from '../test-workspace';
 import {logStep} from '../util';
+
+import {parseDependencyMappingInput} from './util';
 
 const githubTokenMessage = `
 You need to create a github token and place it in a file named 'github-token'.
@@ -97,6 +100,17 @@ function loadGitHubToken(): string|null {
 export default async function run(options: CliOptions) {
   const workspaceDir = path.resolve(options['workspace-dir']);
   logStep(1, 3, '🚧', `Setting Up Workspace "${workspaceDir}"...`);
+
+  for (const rawMapping of options['dependency-mapping']) {
+    try {
+      const [bowerName, npmName, npmSemver] =
+          parseDependencyMappingInput(rawMapping);
+      saveDependencyMapping(bowerName, npmName, npmSemver);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  }
 
   if (!options['npm-version']) {
     throw new Error('--npm-version required');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -97,6 +97,15 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
     defaultValue: []
   },
   {
+    name: 'dependency-mapping',
+    type: String,
+    multiple: true,
+    description: 'A set of mapping instructions to map unknown bower ' +
+        'dependencies to npm. Must be of the format "bower,npm,semver".' +
+        'Example: "polymer,@polymer/polymer,^X.X.X". Multiple mappings allowed.',
+    defaultValue: []
+  },
+  {
     name: 'npm-name',
     type: String,
     description: 'npm package name to use for package.json'
@@ -189,6 +198,7 @@ export interface CliOptions {
   exclude: string[];
   include: string[];
   'delete-files': string[];
+  'dependency-mapping': string[];
   'npm-name'?: string;
   'npm-version'?: string;
   clean: boolean;

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+
+/**
+ * Parse a raw CLI input string for a dependency mapping. See
+ * `--dependency-mapping` CLI option document more information on input format.
+ */
+export function parseDependencyMappingInput(rawMapping: string):
+    [string, string, string] {
+  const parsedMapping = rawMapping.split(',');
+  if (parsedMapping.length !== 3) {
+    throw new Error(
+        `--dependency-mapping: Expected format "bower,npm,semver". Actual input "${
+            rawMapping}"`);
+  }
+  return parsedMapping as [string, string, string];
+}

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -30,8 +30,12 @@ interface DependencyMapEntry {
 interface DependencyMap {
   [bower: string]: DependencyMapEntry|undefined;
 }
-const dependencyMap: DependencyMap =
+
+/** The default dependency map from bower->npm. */
+const defualtDependencyMap: DependencyMap =
     fse.readJSONSync(path.join(__dirname, '..', 'dependency-map.json'));
+/** A custom dependency map that the user can add to. */
+const customDependencyMap: DependencyMap = {};
 const warningCache: Set<String> = new Set();
 
 /**
@@ -49,12 +53,22 @@ function getLocalDependencyValue(path: string) {
 }
 
 /**
+ * Save a custom bower->npm dependency mapping for lookup.
+ */
+export function saveDependencyMapping(
+    bowerPackageName: string, npm: string, semver: string) {
+  customDependencyMap[bowerPackageName] = {npm, semver};
+}
+
+
+/**
  * Lookup the corresponding npm package name in our local map. By default, this
  * method will log a standard warning message to the user if no mapping was
  * found.
  */
 export function lookupDependencyMapping(bowerPackageName: string) {
-  const result = dependencyMap[bowerPackageName];
+  const result = customDependencyMap[bowerPackageName] ||
+      defualtDependencyMap[bowerPackageName];
   if (!result && !warningCache.has(bowerPackageName)) {
     warningCache.add(bowerPackageName);
     console.warn(

--- a/src/package-scanner.ts
+++ b/src/package-scanner.ts
@@ -78,8 +78,11 @@ export class PackageScanner {
    * fetch a package manifest from npm. Failing that (no manifest exists, npm
    * cannot be reached, etc.) it will scan the package manually.
    */
-  async scanPackage(): Promise<PackageScanResult> {
-    const resultsFromManifest = await this.getResultsFromManifest();
+  async scanPackage(forceScan = false): Promise<PackageScanResult> {
+    let resultsFromManifest;
+    if (forceScan !== false) {
+      resultsFromManifest = await this.getResultsFromManifest();
+    }
     if (resultsFromManifest !== undefined) {
       this.scanPackageFromManifest(resultsFromManifest);
     } else {

--- a/src/project-scanner.ts
+++ b/src/project-scanner.ts
@@ -76,7 +76,7 @@ export class ProjectScanner {
   /**
    * Scan a document and any of its dependency packages for their new interface.
    */
-  async scanPackage(matchPackageName: string) {
+  async scanPackage(matchPackageName: string, forceScan = false) {
     if (this.scannedPackages.has(matchPackageName)) {
       return;
     }
@@ -85,12 +85,12 @@ export class ProjectScanner {
         this.analysis,
         this.urlHandler,
         this.conversionSettings);
-    await packageScanner.scanPackage();
+    await packageScanner.scanPackage(forceScan);
     // Add this scanner to our cache so that it won't get double scanned.
     this.scannedPackages.set(matchPackageName, packageScanner);
     // Scan all dependencies of this package as well.
     for (const externalDependencyName of packageScanner.externalDependencies) {
-      await this.scanPackage(externalDependencyName);
+      await this.scanPackage(externalDependencyName, false);
     }
   }
 

--- a/src/test-workspace.ts
+++ b/src/test-workspace.ts
@@ -60,7 +60,7 @@ async function installNpmDependencies(repo: WorkspaceRepo) {
  */
 async function testRepo(repo: WorkspaceRepo) {
   const repoDirName = path.basename(repo.dir);
-  const results = await exec(repo.dir, 'wct', ['--npm']);
+  const results = await exec(repo.dir, 'wct', ['--npm', '-l', 'chrome']);
   if (results.stdout.length > 0) {
     console.log(chalk.dim(`${repoDirName}: ${results.stdout}`));
   }

--- a/src/test/unit/cli/util_test.ts
+++ b/src/test/unit/cli/util_test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import {parseDependencyMappingInput} from '../../../cli/util';
+
+
+suite('src/cli/util', () => {
+
+  suite('parseDependencyMappingInput()', () => {
+
+    test(
+        'throws an error when more than 3 comma-seperated values are passed',
+        () => {
+          assert.throws(() => parseDependencyMappingInput(''));
+          assert.throws(() => parseDependencyMappingInput('bad-input'));
+          assert.throws(() => parseDependencyMappingInput('bad,bad'));
+          assert.throws(() => parseDependencyMappingInput('bad,bad,bad,bad'));
+        });
+
+    test('properly parses three comma-seperated values', () => {
+      assert.deepEqual(parseDependencyMappingInput('a,b,c'), ['a', 'b', 'c']);
+      assert.deepEqual(
+          parseDependencyMappingInput('a-a,b-b,^c.c.c'), ['a-a', 'b-b', '^c.c.c']);
+      assert.deepEqual(
+          parseDependencyMappingInput('a.js,b.js,~c.c.c'),
+          ['a.js', 'b.js', '~c.c.c']);
+      assert.deepEqual(
+          parseDependencyMappingInput(
+              'hello-I-am-some_long_weirdPACKAGEname,hello-I-am-some_long_weirdPACKAGEname,^0.0.0-pre.11'),
+          [
+            'hello-I-am-some_long_weirdPACKAGEname',
+            'hello-I-am-some_long_weirdPACKAGEname',
+            '^0.0.0-pre.11'
+          ]);
+    });
+  });
+
+});

--- a/src/test/unit/package-manifest_test.ts
+++ b/src/test/unit/package-manifest_test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import {lookupDependencyMapping, saveDependencyMapping} from '../../package-manifest';
+
+
+suite('src/package-manifest', () => {
+
+  suite('lookupDependencyMapping()', () => {
+    test('returns undefined when dependency map is not known', () => {
+      const result = lookupDependencyMapping('UNKNOWN_PACKAGE_NAME');
+      assert.isUndefined(result);
+    });
+    test('returns dependency mapping info when dependency map is known', () => {
+      const result = lookupDependencyMapping('polymer');
+      assert.deepEqual(result, {
+        npm: '@polymer/polymer',
+        semver: '^3.0.0-pre.10',
+      });
+    });
+  });
+
+  suite('saveDependencyMapping()', () => {
+    test(
+        'saves a dependency mapping for later lookup via lookupDependencyMapping()',
+        () => {
+          const bowerName = 'CUSTOM_BOWER_PACKAGE_NAME';
+          const customMappingInfo = {
+            npm: 'CUSTOM_NPM_PACKAGE_NAME',
+            semver: '^1.2.3'
+          };
+          let result = lookupDependencyMapping(bowerName);
+          assert.isUndefined(result);
+          saveDependencyMapping(
+              bowerName, customMappingInfo.npm, customMappingInfo.semver);
+          result = lookupDependencyMapping(bowerName);
+          assert.deepEqual(result, customMappingInfo);
+        });
+  });
+
+});

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -20,6 +20,7 @@ import {Analyzer, InMemoryOverlayUrlLoader, PackageUrlResolver} from 'polymer-an
 
 import {createDefaultConversionSettings, PartialConversionSettings} from '../../conversion-settings';
 import {getMemberPath} from '../../document-util';
+import {saveDependencyMapping} from '../../package-manifest';
 import {ProjectConverter} from '../../project-converter';
 import {PackageUrlHandler} from '../../urls/package-url-handler';
 import {PackageType} from '../../urls/types';
@@ -36,6 +37,11 @@ A few conventions in these tests:
  */
 
 suite('AnalysisConverter', () => {
+
+  suiteSetup(() => {
+    saveDependencyMapping('some-package', 'some-package', '^1.2.34567890');
+  });
+
   suite('_convertDocument', () => {
     let urlLoader: InMemoryOverlayUrlLoader;
     const urlResolver = new PackageUrlResolver();
@@ -163,7 +169,6 @@ suite('AnalysisConverter', () => {
         'bower_components/dep/dep.html': `<h1>Hi</h1>`,
       });
       const expectedWarnings = [
-        `WARN: bower->npm mapping for "some-package" not found`,
         `WARN: bower->npm mapping for "dep" not found`,
       ];
       assertSources(await convert({expectedWarnings}), {


### PR DESCRIPTION
It's now possible to add custom dependency mappings for conversion.

Example:

```
modulizer --repo XXX YYY ZZZ --dependency-mapping old-name,new-name,^2.0.0 prism,prismjs,^1.0.0
```