### PR TITLE
pass add-import-path to conversion

### DIFF
--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -132,6 +132,7 @@ export default async function run(options: CliOptions) {
     deleteFiles: options['delete-files'],
     flat: options.flat,
     private: options.private,
+    addImportPath: options['add-import-path'],
   });
 
   logStep(3, 3, '🎉', `Conversion Complete!`);


### PR DESCRIPTION
Fixes #359 

Passing `addImportPath` ala [`command-package.ts`](https://github.com/Polymer/polymer-modulizer/blob/master/src/cli/command-package.ts#L99)