### PR TITLE
update dependency map for pre.12, unmapped 3rd party dependencies

### DIFF
--- a/dependency-map.json
+++ b/dependency-map.json
@@ -1,235 +1,235 @@
 {
   "app-layout": {
     "npm": "@polymer/app-layout",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "app-elements": {
     "npm": "@polymer/app-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "app-localize-behavior": {
     "npm": "@polymer/app-localize-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "app-media": {
     "npm": "@polymer/app-media",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "app-pouchdb": {
     "npm": "@polymer/app-pouchdb",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "app-route": {
     "npm": "@polymer/app-route",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "app-storage": {
     "npm": "@polymer/app-storage",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-flex-layout": {
     "npm": "@polymer/iron-flex-layout",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-media-query": {
     "npm": "@polymer/iron-media-query",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-resizable-behavior": {
     "npm": "@polymer/iron-resizable-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-scroll-target-behavior": {
     "npm": "@polymer/iron-scroll-target-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "app-layout-templates": {
     "npm": "@polymer/app-layout-templates",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-icon": {
     "npm": "@polymer/iron-icon",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-icons": {
     "npm": "@polymer/iron-icons",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-selector": {
     "npm": "@polymer/iron-selector",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-drawer-panel": {
     "npm": "@polymer/paper-drawer-panel",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-header-panel": {
     "npm": "@polymer/paper-header-panel",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-icon-button": {
     "npm": "@polymer/paper-icon-button",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-item": {
     "npm": "@polymer/paper-item",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-material": {
     "npm": "@polymer/paper-material",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-menu": {
     "npm": "@polymer/paper-menu",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-styles": {
     "npm": "@polymer/paper-styles",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-toggle-button": {
     "npm": "@polymer/paper-toggle-button",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-toolbar": {
     "npm": "@polymer/paper-toolbar",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-ajax": {
     "npm": "@polymer/iron-ajax",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-location": {
     "npm": "@polymer/iron-location",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "chartjs-element": {
     "npm": "@polymer/chartjs-element",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-component-page": {
     "npm": "@polymer/iron-component-page",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "data-elements": {
     "npm": "@polymer/data-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-jsonp-library": {
     "npm": "@polymer/iron-jsonp-library",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "font-roboto": {
     "npm": "@polymer/font-roboto",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "font-roboto-local": {
     "npm": "@polymer/font-roboto-local",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "gold-cc-cvc-input": {
     "npm": "@polymer/gold-cc-cvc-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-form-element-behavior": {
     "npm": "@polymer/iron-form-element-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-input": {
     "npm": "@polymer/paper-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "gold-cc-expiration-input": {
     "npm": "@polymer/gold-cc-expiration-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-a11y-keys-behavior": {
     "npm": "@polymer/iron-a11y-keys-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-validator-behavior": {
     "npm": "@polymer/iron-validator-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-validatable-behavior": {
     "npm": "@polymer/iron-validatable-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "gold-cc-input": {
     "npm": "@polymer/gold-cc-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "gold-elements": {
     "npm": "@polymer/gold-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "gold-email-input": {
     "npm": "@polymer/gold-email-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "gold-phone-input": {
     "npm": "@polymer/gold-phone-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "gold-zip-input": {
     "npm": "@polymer/gold-zip-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-input": {
     "npm": "@polymer/iron-input",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-a11y-announcer": {
     "npm": "@polymer/iron-a11y-announcer",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-a11y-keys": {
     "npm": "@polymer/iron-a11y-keys",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-autogrow-textarea": {
     "npm": "@polymer/iron-autogrow-textarea",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-behaviors": {
     "npm": "@polymer/iron-behaviors",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-behaviors-collection": {
     "npm": "@polymer/iron-behaviors-collection",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-range-behavior": {
     "npm": "@polymer/iron-range-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-overlay-behavior": {
     "npm": "@polymer/iron-overlay-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-scroll-threshold": {
     "npm": "@polymer/iron-scroll-threshold",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-menu-behavior": {
     "npm": "@polymer/iron-menu-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-checked-element-behavior": {
     "npm": "@polymer/iron-checked-element-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-collapse": {
     "npm": "@polymer/iron-collapse",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-doc-viewer": {
     "npm": "@polymer/iron-doc-viewer",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-demo-helpers": {
     "npm": "@polymer/iron-demo-helpers",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "marked": {
     "npm": "marked",
@@ -237,7 +237,7 @@
   },
   "marked-element": {
     "npm": "@polymer/marked-element",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "prism": {
     "npm": "prismjs",
@@ -245,247 +245,247 @@
   },
   "prism-element": {
     "npm": "@polymer/prism-element",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-button": {
     "npm": "@polymer/paper-button",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-dropdown": {
     "npm": "@polymer/iron-dropdown",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "neon-animation": {
     "npm": "@polymer/neon-animation",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-elements": {
     "npm": "@polymer/iron-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "icon-behaviors-collection": {
     "npm": "@polymer/icon-behaviors-collection",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "icon-input-elements": {
     "npm": "@polymer/icon-input-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-fit-behavior": {
     "npm": "@polymer/iron-fit-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-iconset": {
     "npm": "@polymer/iron-iconset",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-iconset-svg": {
     "npm": "@polymer/iron-iconset-svg",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-image": {
     "npm": "@polymer/iron-image",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-list": {
     "npm": "@polymer/iron-list",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-pages": {
     "npm": "@polymer/iron-pages",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-swipeable-container": {
     "npm": "@polymer/iron-swipeable-container",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-test-helpers": {
     "npm": "@polymer/iron-test-helpers",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-form": {
     "npm": "@polymer/iron-form",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-meta": {
     "npm": "@polymer/iron-meta",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-input-elements": {
     "npm": "@polymer/iron-input-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-label": {
     "npm": "@polymer/iron-label",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-localstorage": {
     "npm": "@polymer/iron-localstorage",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "iron-signals": {
     "npm": "@polymer/iron-signals",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "layout-elements": {
     "npm": "@polymer/layout-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "neon-elements": {
     "npm": "@polymer/neon-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-badge": {
     "npm": "@polymer/paper-badge",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-behaviors": {
     "npm": "@polymer/paper-behaviors",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-ripple": {
     "npm": "@polymer/paper-ripple",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-card": {
     "npm": "@polymer/paper-card",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-checkbox": {
     "npm": "@polymer/paper-checkbox",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-dialog": {
     "npm": "@polymer/paper-dialog",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-dialog-behavior": {
     "npm": "@polymer/paper-dialog-behavior",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-dialog-scrollable": {
     "npm": "@polymer/paper-dialog-scrollable",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-dropdown-menu": {
     "npm": "@polymer/paper-dropdown-menu",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-menu-button": {
     "npm": "@polymer/paper-menu-button",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-elements": {
     "npm": "@polymer/paper-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-input-elements": {
     "npm": "@polymer/paper-input-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-overlay-elements": {
     "npm": "@polymer/paper-overlay-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-ui-elements": {
     "npm": "@polymer/paper-ui-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-fab": {
     "npm": "@polymer/paper-fab",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-listbox": {
     "npm": "@polymer/paper-listbox",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-radio-button": {
     "npm": "@polymer/paper-radio-button",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-radio-group": {
     "npm": "@polymer/paper-radio-group",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-slider": {
     "npm": "@polymer/paper-slider",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-linear-progress": {
     "npm": "@polymer/paper-linear-progress",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-progress": {
     "npm": "@polymer/paper-progress",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-scroll-header-panel": {
     "npm": "@polymer/paper-scroll-header-panel",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-spinner": {
     "npm": "@polymer/paper-spinner",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-swatch-picker": {
     "npm": "@polymer/paper-swatch-picker",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-tabs": {
     "npm": "@polymer/paper-tabs",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-text-field": {
     "npm": "@polymer/paper-text-field",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-toast": {
     "npm": "@polymer/paper-toast",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "paper-tooltip": {
     "npm": "@polymer/paper-tooltip",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "platinum-bluetooth": {
     "npm": "@polymer/platinum-bluetooth",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "platinum-elements": {
     "npm": "@polymer/platinum-elements",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "platinum-https-redirect": {
     "npm": "@polymer/platinum-https-redirect",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "platinum-push-messaging": {
     "npm": "@polymer/platinum-push-messaging",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "platinum-sw": {
     "npm": "@polymer/platinum-sw",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "polymer-starter-kit": {
     "npm": "@polymer/polymer-starter-kit",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "promise-polyfill": {
     "npm": "@polymer/promise-polyfill",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "seed-element": {
     "npm": "@polymer/seed-element",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "performance-benchmark": {
     "npm": "@polymer/performance-benchmark",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "test-fixture": {
     "npm": "@polymer/test-fixture",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "shadycss": {
     "npm": "@webcomponents/shadycss",
@@ -497,7 +497,7 @@
   },
   "polymer": {
     "npm": "@polymer/polymer",
-    "semver": "^3.0.0-pre.10"
+    "semver": "3.0.0-pre.12"
   },
   "hydrolysis": {
     "npm": "hydrolysis",
@@ -510,5 +510,29 @@
   "web-animations-js": {
     "npm": "web-animations-js",
     "semver": "^2.3.1"
+  },
+  "intl-messageformat": {
+    "npm": "intl-messageformat",
+    "semver": "^2.2.0"
+  },
+  "intl": {
+    "npm": "intl",
+    "semver": "^1.2.0"
+  },
+  "imagecapture-polyfill": {
+    "npm": "image-capture",
+    "semver": "^0.3.0"
+  },
+  "fetch": {
+    "npm": "whatwg-fetch",
+    "semver": "^2.0.0"
+  },
+  "sw-toolbox": {
+    "npm": "sw-toolbox",
+    "semver": "^3.6.0"
+  },
+  "es6-promise": {
+    "npm": "es6-promise",
+    "semver": "^4.0.0"
   }
 }

--- a/fixtures/packages/iron-icon/expected/package.json
+++ b/fixtures/packages/iron-icon/expected/package.json
@@ -14,13 +14,13 @@
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
     "bower": "^1.8.0",
-    "@polymer/promise-polyfill": "^3.0.0-pre.10",
-    "@polymer/iron-iconset": "^3.0.0-pre.10",
-    "@polymer/iron-icons": "^3.0.0-pre.10",
-    "@polymer/iron-component-page": "^3.0.0-pre.10",
+    "@polymer/promise-polyfill": "3.0.0-pre.12",
+    "@polymer/iron-iconset": "3.0.0-pre.12",
+    "@polymer/iron-icons": "3.0.0-pre.12",
+    "@polymer/iron-component-page": "3.0.0-pre.12",
     "wct-browser-legacy": "0.0.1-pre.11",
     "@webcomponents/webcomponentsjs": "^1.0.0",
-    "@polymer/iron-demo-helpers": "^3.0.0-pre.10"
+    "@polymer/iron-demo-helpers": "3.0.0-pre.12"
   },
   "scripts": {
     "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
@@ -35,8 +35,8 @@
   "main": "iron-icon.js",
   "author": "The Polymer Authors",
   "dependencies": {
-    "@polymer/iron-flex-layout": "^3.0.0-pre.10",
-    "@polymer/iron-meta": "^3.0.0-pre.10",
-    "@polymer/polymer": "^3.0.0-pre.10"
+    "@polymer/iron-flex-layout": "3.0.0-pre.12",
+    "@polymer/iron-meta": "3.0.0-pre.12",
+    "@polymer/polymer": "3.0.0-pre.12"
   }
 }

--- a/fixtures/packages/paper-button/expected/package.json
+++ b/fixtures/packages/paper-button/expected/package.json
@@ -24,18 +24,18 @@
   "author": "The Polymer Authors",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@polymer/polymer": "^3.0.0-pre.10",
-    "@polymer/iron-flex-layout": "^3.0.0-pre.10",
-    "@polymer/paper-behaviors": "^3.0.0-pre.10",
-    "@polymer/paper-styles": "^3.0.0-pre.10"
+    "@polymer/polymer": "3.0.0-pre.12",
+    "@polymer/iron-flex-layout": "3.0.0-pre.12",
+    "@polymer/paper-behaviors": "3.0.0-pre.12",
+    "@polymer/paper-styles": "3.0.0-pre.12"
   },
   "devDependencies": {
-    "@polymer/iron-component-page": "^3.0.0-pre.10",
-    "@polymer/iron-demo-helpers": "^3.0.0-pre.10",
-    "@polymer/iron-icon": "^3.0.0-pre.10",
-    "@polymer/iron-icons": "^3.0.0-pre.10",
-    "@polymer/iron-test-helpers": "^3.0.0-pre.10",
-    "@polymer/test-fixture": "^3.0.0-pre.10",
+    "@polymer/iron-component-page": "3.0.0-pre.12",
+    "@polymer/iron-demo-helpers": "3.0.0-pre.12",
+    "@polymer/iron-icon": "3.0.0-pre.12",
+    "@polymer/iron-icons": "3.0.0-pre.12",
+    "@polymer/iron-test-helpers": "3.0.0-pre.12",
+    "@polymer/test-fixture": "3.0.0-pre.12",
     "wct-browser-legacy": "0.0.1-pre.11",
     "@webcomponents/webcomponentsjs": "^1.0.0"
   }

--- a/fixtures/packages/polymer/expected/package.json
+++ b/fixtures/packages/polymer/expected/package.json
@@ -38,7 +38,7 @@
     "through2": "^2.0.0",
     "web-component-tester": "^6.5.0",
     "wct-browser-legacy": "0.0.1-pre.11",
-    "@polymer/test-fixture": "^3.0.0-pre.10"
+    "@polymer/test-fixture": "3.0.0-pre.12"
   },
   "scripts": {
     "build": "gulp",

--- a/src/test/unit/package-manifest_test.ts
+++ b/src/test/unit/package-manifest_test.ts
@@ -33,7 +33,7 @@ suite('src/package-manifest', () => {
       const result = lookupDependencyMapping('polymer');
       assert.deepEqual(result, {
         npm: '@polymer/polymer',
-        semver: '^3.0.0-pre.10',
+        semver: '3.0.0-pre.12',
       });
     });
   });


### PR DESCRIPTION
- After each release, we update the dependency map to the new released version tag
- We've decided to remove the leading `^` from our own dependencies going forward, so that we can test breaking changes under the `next` tag before sharing them with our users.
- This PR also adds some previously unmapped dependencies