### PR TITLE
Preserve comments in rewrite namespace exports pass.

### DIFF
--- a/fixtures/packages/polymer/expected/lib/elements/array-selector.js
+++ b/fixtures/packages/polymer/expected/lib/elements/array-selector.js
@@ -327,6 +327,7 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
 
 });
 
+// export mixin
 export { ArraySelectorMixin };
 
 /**

--- a/fixtures/packages/polymer/expected/lib/elements/dom-module.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-module.js
@@ -127,4 +127,5 @@ DomModule.prototype['modules'] = modules;
 
 customElements.define('dom-module', DomModule);
 
+// export
 export { DomModule };

--- a/fixtures/packages/polymer/expected/lib/legacy/class.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/class.js
@@ -275,6 +275,73 @@ function GenerateClassFromInfo(info, Base) {
   return PolymerGenerated;
 }
 
+/**
+ * Generates a class that extends `Polymer.LegacyElement` based on the
+ * provided info object.  Metadata objects on the `info` object
+ * (`properties`, `observers`, `listeners`, `behaviors`, `is`) are used
+ * for Polymer's meta-programming systems, and any functions are copied
+ * to the generated class.
+ *
+ * Valid "metadata" values are as follows:
+ *
+ * `is`: String providing the tag name to register the element under. In
+ * addition, if a `dom-module` with the same id exists, the first template
+ * in that `dom-module` will be stamped into the shadow root of this element,
+ * with support for declarative event listeners (`on-...`), Polymer data
+ * bindings (`[[...]]` and `{{...}}`), and id-based node finding into
+ * `this.$`.
+ *
+ * `properties`: Object describing property-related metadata used by Polymer
+ * features (key: property names, value: object containing property metadata).
+ * Valid keys in per-property metadata include:
+ * - `type` (String|Number|Object|Array|...): Used by
+ *   `attributeChangedCallback` to determine how string-based attributes
+ *   are deserialized to JavaScript property values.
+ * - `notify` (boolean): Causes a change in the property to fire a
+ *   non-bubbling event called `<property>-changed`. Elements that have
+ *   enabled two-way binding to the property use this event to observe changes.
+ * - `readOnly` (boolean): Creates a getter for the property, but no setter.
+ *   To set a read-only property, use the private setter method
+ *   `_setProperty(property, value)`.
+ * - `observer` (string): Observer method name that will be called when
+ *   the property changes. The arguments of the method are
+ *   `(value, previousValue)`.
+ * - `computed` (string): String describing method and dependent properties
+ *   for computing the value of this property (e.g. `'computeFoo(bar, zot)'`).
+ *   Computed properties are read-only by default and can only be changed
+ *   via the return value of the computing method.
+ *
+ * `observers`: Array of strings describing multi-property observer methods
+ *  and their dependent properties (e.g. `'observeABC(a, b, c)'`).
+ *
+ * `listeners`: Object describing event listeners to be added to each
+ *  instance of this element (key: event name, value: method name).
+ *
+ * `behaviors`: Array of additional `info` objects containing metadata
+ * and callbacks in the same format as the `info` object here which are
+ * merged into this element.
+ *
+ * `hostAttributes`: Object listing attributes to be applied to the host
+ *  once created (key: attribute name, value: attribute value).  Values
+ *  are serialized based on the type of the value.  Host attributes should
+ *  generally be limited to attributes such as `tabIndex` and `aria-...`.
+ *  Attributes in `hostAttributes` are only applied if a user-supplied
+ *  attribute is not already present (attributes in markup override
+ *  `hostAttributes`).
+ *
+ * In addition, the following Polymer-specific callbacks may be provided:
+ * - `registered`: called after first instance of this element,
+ * - `created`: called during `constructor`
+ * - `attached`: called during `connectedCallback`
+ * - `detached`: called during `disconnectedCallback`
+ * - `ready`: called before first `attached`, after all properties of
+ *   this element have been propagated to its template and all observers
+ *   have run
+ *
+ * @param {!PolymerInit} info Object containing Polymer metadata and functions
+ *   to become class methods.
+ * @return {function(new:HTMLElement)} Generated class
+ */
 export const Class = function(info) {
   if (!info) {
     console.warn('Polymer.Class requires `info` argument');

--- a/fixtures/packages/polymer/expected/lib/legacy/legacy-element-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/legacy-element-mixin.js
@@ -14,6 +14,20 @@ import { get as get$0 } from '../utils/path.js';
 
 let styleInterface = window.ShadyCSS;
 
+/**
+ * Element class mixin that provides Polymer's "legacy" API intended to be
+ * backward-compatible to the greatest extent possible with the API
+ * found on the Polymer 1.x `Polymer.Base` prototype applied to all elements
+ * defined using the `Polymer({...})` function.
+ *
+ * @mixinFunction
+ * @polymer
+ * @appliesMixin Polymer.ElementMixin
+ * @appliesMixin Polymer.GestureEventListeners
+ * @property isAttached {boolean} Set to `true` in this element's
+ *   `connectedCallback` and `false` in `disconnectedCallback`
+ * @summary Element class mixin that provides Polymer's "legacy" API
+ */
 export const LegacyElementMixin = dedupingMixin((base) => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/legacy/mutable-data-behavior.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/mutable-data-behavior.js
@@ -6,6 +6,43 @@ let mutablePropertyChange;
   mutablePropertyChange = MutableData._mutablePropertyChange;
 })();
 
+/**
+ * Legacy element behavior to skip strict dirty-checking for objects and arrays,
+ * (always consider them to be "dirty") for use on legacy API Polymer elements.
+ *
+ * By default, `Polymer.PropertyEffects` performs strict dirty checking on
+ * objects, which means that any deep modifications to an object or array will
+ * not be propagated unless "immutable" data patterns are used (i.e. all object
+ * references from the root to the mutation were changed).
+ *
+ * Polymer also provides a proprietary data mutation and path notification API
+ * (e.g. `notifyPath`, `set`, and array mutation API's) that allow efficient
+ * mutation and notification of deep changes in an object graph to all elements
+ * bound to the same object graph.
+ *
+ * In cases where neither immutable patterns nor the data mutation API can be
+ * used, applying this mixin will cause Polymer to skip dirty checking for
+ * objects and arrays (always consider them to be "dirty").  This allows a
+ * user to make a deep modification to a bound object graph, and then either
+ * simply re-set the object (e.g. `this.items = this.items`) or call `notifyPath`
+ * (e.g. `this.notifyPath('items')`) to update the tree.  Note that all
+ * elements that wish to be updated based on deep mutations must apply this
+ * mixin or otherwise skip strict dirty checking for objects/arrays.
+ * Specifically, any elements in the binding tree between the source of a
+ * mutation and the consumption of it must apply this behavior or enable the
+ * `Polymer.OptionalMutableDataBehavior`.
+ *
+ * In order to make the dirty check strategy configurable, see
+ * `Polymer.OptionalMutableDataBehavior`.
+ *
+ * Note, the performance characteristics of propagating large object graphs
+ * will be worse as opposed to using strict dirty checking with immutable
+ * patterns or Polymer's path notification API.
+ *
+ * @polymerBehavior
+ * @summary Behavior to skip strict dirty-checking for objects and
+ *   arrays
+ */
 export const MutableDataBehavior = {
 
   /**
@@ -30,6 +67,45 @@ export const MutableDataBehavior = {
   }
 };
 
+/**
+ * Legacy element behavior to add the optional ability to skip strict
+ * dirty-checking for objects and arrays (always consider them to be
+ * "dirty") by setting a `mutable-data` attribute on an element instance.
+ *
+ * By default, `Polymer.PropertyEffects` performs strict dirty checking on
+ * objects, which means that any deep modifications to an object or array will
+ * not be propagated unless "immutable" data patterns are used (i.e. all object
+ * references from the root to the mutation were changed).
+ *
+ * Polymer also provides a proprietary data mutation and path notification API
+ * (e.g. `notifyPath`, `set`, and array mutation API's) that allow efficient
+ * mutation and notification of deep changes in an object graph to all elements
+ * bound to the same object graph.
+ *
+ * In cases where neither immutable patterns nor the data mutation API can be
+ * used, applying this mixin will allow Polymer to skip dirty checking for
+ * objects and arrays (always consider them to be "dirty").  This allows a
+ * user to make a deep modification to a bound object graph, and then either
+ * simply re-set the object (e.g. `this.items = this.items`) or call `notifyPath`
+ * (e.g. `this.notifyPath('items')`) to update the tree.  Note that all
+ * elements that wish to be updated based on deep mutations must apply this
+ * mixin or otherwise skip strict dirty checking for objects/arrays.
+ * Specifically, any elements in the binding tree between the source of a
+ * mutation and the consumption of it must enable this behavior or apply the
+ * `Polymer.OptionalMutableDataBehavior`.
+ *
+ * While this behavior adds the ability to forgo Object/Array dirty checking,
+ * the `mutableData` flag defaults to false and must be set on the instance.
+ *
+ * Note, the performance characteristics of propagating large object graphs
+ * will be worse by relying on `mutableData: true` as opposed to using
+ * strict dirty checking with immutable patterns or Polymer's path notification
+ * API.
+ *
+ * @polymerBehavior
+ * @summary Behavior to optionally skip strict dirty-checking for objects and
+ *   arrays
+ */
 export const OptionalMutableDataBehavior = {
 
   properties: {

--- a/fixtures/packages/polymer/expected/lib/legacy/polymer-fn.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/polymer-fn.js
@@ -1,5 +1,22 @@
 import { Class } from './class.js';
 
+/**
+ * Legacy class factory and registration helper for defining Polymer
+ * elements.
+ *
+ * This method is equivalent to
+ * `customElements.define(info.is, Polymer.Class(info));`
+ *
+ * See `Polymer.Class` for details on valid legacy metadata format for `info`.
+ *
+ * @global
+ * @override
+ * @function Polymer
+ * @param {!PolymerInit} info Object containing Polymer metadata and functions
+ *   to become class methods.
+ * @return {function(new: HTMLElement)} Generated class
+ * @suppress {duplicate, invalidCasts, checkTypes}
+ */
 export const Polymer = function(info) {
   // if input is a `class` (aka a function with a prototype), use the prototype
   // remember that the `constructor` will never be called

--- a/fixtures/packages/polymer/expected/lib/legacy/polymer.dom.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/polymer.dom.js
@@ -337,6 +337,20 @@ DomApi.prototype.querySelector;
  */
 DomApi.prototype.querySelectorAll;
 
+/**
+ * Legacy DOM and Event manipulation API wrapper factory used to abstract
+ * differences between native Shadow DOM and "Shady DOM" when polyfilling on
+ * older browsers.
+ *
+ * Note that in Polymer 2.x use of `Polymer.dom` is no longer required and
+ * in the majority of cases simply facades directly to the standard native
+ * API.
+ *
+ * @summary Legacy DOM and Event manipulation API wrapper factory used to
+ * abstract differences between native Shadow DOM and "Shady DOM."
+ * @param {(Node|Event)=} obj Node or event to operate on
+ * @return {!DomApi|!EventApi} Wrapper providing either node API or event API
+ */
 export const dom = function(obj) {
   obj = obj || document;
   if (!obj.__domApi) {
@@ -352,5 +366,22 @@ export const dom = function(obj) {
 };
 
 export { matchesSelector };
+
+/**
+ * Forces several classes of asynchronously queued tasks to flush:
+ * - Debouncers added via `Polymer.enqueueDebouncer`
+ * - ShadyDOM distribution
+ *
+ * This method facades to `Polymer.flush`.
+ *
+ */
 export { flush$0 as flush };
+
+/**
+ * Adds a `Polymer.Debouncer` to a list of globally flushable tasks.
+ *
+ * This method facades to `Polymer.enqueueDebouncer`.
+ *
+ * @param {Polymer.Debouncer} debouncer Debouncer to enqueue
+ */
 export { enqueueDebouncer as addDebouncer };

--- a/fixtures/packages/polymer/expected/lib/legacy/templatizer-behavior.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/templatizer-behavior.js
@@ -14,6 +14,66 @@ let TemplateInstanceBase = TemplateInstanceBase$0; // eslint-disable-line
  */
 let TemplatizerUser; // eslint-disable-line
 
+/**
+ * The `Polymer.Templatizer` behavior adds methods to generate instances of
+ * templates that are each managed by an anonymous `Polymer.PropertyEffects`
+ * instance where data-bindings in the stamped template content are bound to
+ * accessors on itself.
+ *
+ * This behavior is provided in Polymer 2.x as a hybrid-element convenience
+ * only.  For non-hybrid usage, the `Polymer.Templatize` library
+ * should be used instead.
+ *
+ * Example:
+ *
+ *     // Get a template from somewhere, e.g. light DOM
+ *     let template = this.querySelector('template');
+ *     // Prepare the template
+ *     this.templatize(template);
+ *     // Instance the template with an initial data model
+ *     let instance = this.stamp({myProp: 'initial'});
+ *     // Insert the instance's DOM somewhere, e.g. light DOM
+ *     Polymer.dom(this).appendChild(instance.root);
+ *     // Changing a property on the instance will propagate to bindings
+ *     // in the template
+ *     instance.myProp = 'new value';
+ *
+ * Users of `Templatizer` may need to implement the following abstract
+ * API's to determine how properties and paths from the host should be
+ * forwarded into to instances:
+ *
+ *     _forwardHostPropV2: function(prop, value)
+ *
+ * Likewise, users may implement these additional abstract API's to determine
+ * how instance-specific properties that change on the instance should be
+ * forwarded out to the host, if necessary.
+ *
+ *     _notifyInstancePropV2: function(inst, prop, value)
+ *
+ * In order to determine which properties are instance-specific and require
+ * custom notification via `_notifyInstanceProp`, define an `_instanceProps`
+ * object containing keys for each instance prop, for example:
+ *
+ *     _instanceProps: {
+ *       item: true,
+ *       index: true
+ *     }
+ *
+ * Any properties used in the template that are not defined in _instanceProp
+ * will be forwarded out to the Templatize `owner` automatically.
+ *
+ * Users may also implement the following abstract function to show or
+ * hide any DOM generated using `stamp`:
+ *
+ *     _showHideChildren: function(shouldHide)
+ *
+ * Note that some callbacks are suffixed with `V2` in the Polymer 2.x behavior
+ * as the implementations will need to differ from the callbacks required
+ * by the 1.x Templatizer API due to changes in the `TemplateInstance` API
+ * between versions 1.x and 2.x.
+ *
+ * @polymerBehavior
+ */
 export const Templatizer = {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/mixins/dir-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/dir-mixin.js
@@ -45,6 +45,26 @@ function takeRecords() {
   }
 }
 
+/**
+ * Element class mixin that allows elements to use the `:dir` CSS Selector to have
+ * text direction specific styling.
+ *
+ * With this mixin, any stylesheet provided in the template will transform `:dir` into
+ * `:host([dir])` and sync direction with the page via the element's `dir` attribute.
+ *
+ * Elements can opt out of the global page text direction by setting the `dir` attribute
+ * directly in `ready()` or in HTML.
+ *
+ * Caveats:
+ * - Applications must set `<html dir="ltr">` or `<html dir="rtl">` to sync direction
+ * - Automatic left-to-right or right-to-left styling is sync'd with the `<html>` element only.
+ * - Changing `dir` at runtime is supported.
+ * - Opting out of the global direction styling is permanent
+ *
+ * @mixinFunction
+ * @polymer
+ * @appliesMixin Polymer.PropertyAccessors
+ */
 export const DirMixin = dedupingMixin((base) => {
 
   if (!observer) {

--- a/fixtures/packages/polymer/expected/lib/mixins/disable-upgrade-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/disable-upgrade-mixin.js
@@ -3,6 +3,30 @@ import { dedupingMixin } from '../utils/mixin.js';
 
 const DISABLED_ATTR = 'disable-upgrade';
 
+/**
+ * Element class mixin that allows the element to boot up in a non-enabled
+ * state when the `disable-upgrade` attribute is present. This mixin is
+ * designed to be used with element classes like Polymer.Element that perform
+ * initial startup work when they are first connected. When the
+ * `disable-upgrade` attribute is removed, if the element is connected, it
+ * boots up and "enables" as it otherwise would; if it is not connected, the
+ * element boots up when it is next connected.
+ *
+ * Using `disable-upgrade` with Polymer.Element prevents any data propagation
+ * to the element, any element DOM from stamping, or any work done in
+ * connected/disconnctedCallback from occuring, but it does not prevent work
+ * done in the element constructor.
+ *
+ * Note, this mixin must be applied on top of any element class that
+ * itself implements a `connectedCallback` so that it can control the work
+ * done in `connectedCallback`. For example,
+ *
+ *     MyClass = Polymer.DisableUpgradeMixin(class extends BaseClass {...});
+ *
+ * @mixinFunction
+ * @polymer
+ * @appliesMixin Polymer.ElementMixin
+ */
 export const DisableUpgradeMixin = dedupingMixin((base) => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/mixins/gesture-event-listeners.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/gesture-event-listeners.js
@@ -7,6 +7,20 @@ import * as gestures$0 from '../utils/gestures.js';
  */
 const gestures = gestures$0;
 
+/**
+ * Element class mixin that provides API for adding Polymer's cross-platform
+ * gesture events to nodes.
+ *
+ * The API is designed to be compatible with override points implemented
+ * in `Polymer.TemplateStamp` such that declarative event listeners in
+ * templates will support gesture events when this mixin is applied along with
+ * `Polymer.TemplateStamp`.
+ *
+ * @mixinFunction
+ * @polymer
+ * @summary Element class mixin that provides API for adding Polymer's cross-platform
+ * gesture events to nodes
+ */
 export const GestureEventListeners = dedupingMixin(superClass => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/mixins/mutable-data.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/mutable-data.js
@@ -20,6 +20,45 @@ function mutablePropertyChange(inst, property, value, old, mutableData) {
   return shouldChange;
 }
 
+/**
+ * Element class mixin to skip strict dirty-checking for objects and arrays
+ * (always consider them to be "dirty"), for use on elements utilizing
+ * `Polymer.PropertyEffects`
+ *
+ * By default, `Polymer.PropertyEffects` performs strict dirty checking on
+ * objects, which means that any deep modifications to an object or array will
+ * not be propagated unless "immutable" data patterns are used (i.e. all object
+ * references from the root to the mutation were changed).
+ *
+ * Polymer also provides a proprietary data mutation and path notification API
+ * (e.g. `notifyPath`, `set`, and array mutation API's) that allow efficient
+ * mutation and notification of deep changes in an object graph to all elements
+ * bound to the same object graph.
+ *
+ * In cases where neither immutable patterns nor the data mutation API can be
+ * used, applying this mixin will cause Polymer to skip dirty checking for
+ * objects and arrays (always consider them to be "dirty").  This allows a
+ * user to make a deep modification to a bound object graph, and then either
+ * simply re-set the object (e.g. `this.items = this.items`) or call `notifyPath`
+ * (e.g. `this.notifyPath('items')`) to update the tree.  Note that all
+ * elements that wish to be updated based on deep mutations must apply this
+ * mixin or otherwise skip strict dirty checking for objects/arrays.
+ * Specifically, any elements in the binding tree between the source of a
+ * mutation and the consumption of it must apply this mixin or enable the
+ * `Polymer.OptionalMutableData` mixin.
+ *
+ * In order to make the dirty check strategy configurable, see
+ * `Polymer.OptionalMutableData`.
+ *
+ * Note, the performance characteristics of propagating large object graphs
+ * will be worse as opposed to using strict dirty checking with immutable
+ * patterns or Polymer's path notification API.
+ *
+ * @mixinFunction
+ * @polymer
+ * @summary Element class mixin to skip strict dirty-checking for objects
+ *   and arrays
+ */
 export const MutableData = dedupingMixin(superClass => {
 
   /**
@@ -55,6 +94,46 @@ export const MutableData = dedupingMixin(superClass => {
 
 });
 
+/**
+ * Element class mixin to add the optional ability to skip strict
+ * dirty-checking for objects and arrays (always consider them to be
+ * "dirty") by setting a `mutable-data` attribute on an element instance.
+ *
+ * By default, `Polymer.PropertyEffects` performs strict dirty checking on
+ * objects, which means that any deep modifications to an object or array will
+ * not be propagated unless "immutable" data patterns are used (i.e. all object
+ * references from the root to the mutation were changed).
+ *
+ * Polymer also provides a proprietary data mutation and path notification API
+ * (e.g. `notifyPath`, `set`, and array mutation API's) that allow efficient
+ * mutation and notification of deep changes in an object graph to all elements
+ * bound to the same object graph.
+ *
+ * In cases where neither immutable patterns nor the data mutation API can be
+ * used, applying this mixin will allow Polymer to skip dirty checking for
+ * objects and arrays (always consider them to be "dirty").  This allows a
+ * user to make a deep modification to a bound object graph, and then either
+ * simply re-set the object (e.g. `this.items = this.items`) or call `notifyPath`
+ * (e.g. `this.notifyPath('items')`) to update the tree.  Note that all
+ * elements that wish to be updated based on deep mutations must apply this
+ * mixin or otherwise skip strict dirty checking for objects/arrays.
+ * Specifically, any elements in the binding tree between the source of a
+ * mutation and the consumption of it must enable this mixin or apply the
+ * `Polymer.MutableData` mixin.
+ *
+ * While this mixin adds the ability to forgo Object/Array dirty checking,
+ * the `mutableData` flag defaults to false and must be set on the instance.
+ *
+ * Note, the performance characteristics of propagating large object graphs
+ * will be worse by relying on `mutableData: true` as opposed to using
+ * strict dirty checking with immutable patterns or Polymer's path notification
+ * API.
+ *
+ * @mixinFunction
+ * @polymer
+ * @summary Element class mixin to optionally skip strict dirty-checking
+ *   for objects and arrays
+ */
 export const OptionalMutableData = dedupingMixin(superClass => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/mixins/properties-changed.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/properties-changed.js
@@ -5,6 +5,24 @@ import { microTask } from '../utils/async.js';
 /** @const {!AsyncInterface} */
 const microtask = microTask;
 
+/**
+ * Element class mixin that provides basic meta-programming for creating one
+ * or more property accessors (getter/setter pair) that enqueue an async
+ * (batched) `_propertiesChanged` callback.
+ *
+ * For basic usage of this mixin, call `MyClass.createProperties(props)`
+ * once at class definition time to create property accessors for properties
+ * named in props, implement `_propertiesChanged` to react as desired to
+ * property changes, and implement `static get observedAttributes()` and
+ * include lowercase versions of any property names that should be set from
+ * attributes. Last, call `this._enableProperties()` in the element's
+ * `connectedCallback` to enable the accessors.
+ *
+ * @mixinFunction
+ * @polymer
+ * @summary Element class mixin for reacting to property changes from
+ *   generated property accessors.
+ */
 export const PropertiesChanged = dedupingMixin(superClass => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/mixins/properties-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/properties-mixin.js
@@ -20,6 +20,23 @@ function normalizeProperties(props) {
   return output;
 }
 
+/**
+ * Mixin that provides a minimal starting point to using the PropertiesChanged
+ * mixin by providing a mechanism to declare properties in a static
+ * getter (e.g. static get properties() { return { foo: String } }). Changes
+ * are reported via the `_propertiesChanged` method.
+ *
+ * This mixin provides no specific support for rendering. Users are expected
+ * to create a ShadowRoot and put content into it and update it in whatever
+ * way makes sense. This can be done in reaction to properties changing by
+ * implementing `_propertiesChanged`.
+ *
+ * @mixinFunction
+ * @polymer
+ * @appliesMixin Polymer.PropertiesChanged
+ * @summary Mixin that provides a minimal starting point for using
+ * the PropertiesChanged mixin by providing a declarative `properties` object.
+ */
 export const PropertiesMixin = dedupingMixin(superClass => {
 
  /**

--- a/fixtures/packages/polymer/expected/lib/mixins/property-accessors.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/property-accessors.js
@@ -54,6 +54,34 @@ function saveAccessorValue(model, property) {
   }
 }
 
+/**
+ * Element class mixin that provides basic meta-programming for creating one
+ * or more property accessors (getter/setter pair) that enqueue an async
+ * (batched) `_propertiesChanged` callback.
+ *
+ * For basic usage of this mixin:
+ * 
+ * -   Declare attributes to observe via the standard `static get observedAttributes()`. Use
+ *     `dash-case` attribute names to represent `camelCase` property names. 
+ * -   Implement the `_propertiesChanged` callback on the class.
+ * -   Call `MyClass.createPropertiesForAttributes()` **once** on the class to generate 
+ *     property accessors for each observed attribute. This must be called before the first 
+ *     instance is created, for example, by calling it before calling `customElements.define`.
+ *     It can also be called lazily from the element's `constructor`, as long as it's guarded so
+ *     that the call is only made once, when the first instance is created.
+ * -   Call `this._enableProperties()` in the element's `connectedCallback` to enable 
+ *     the accessors.
+ *
+ * Any `observedAttributes` will automatically be
+ * deserialized via `attributeChangedCallback` and set to the associated
+ * property using `dash-case`-to-`camelCase` convention.
+ *
+ * @mixinFunction
+ * @polymer
+ * @appliesMixin Polymer.PropertiesChanged
+ * @summary Element class mixin for reacting to property changes from
+ *   generated property accessors.
+ */
 export const PropertyAccessors = dedupingMixin(superClass => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/mixins/property-effects.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/property-effects.js
@@ -1059,6 +1059,41 @@ function upper(name) {
   return name[0].toUpperCase() + name.substring(1);
 }
 
+/**
+ * Element class mixin that provides meta-programming for Polymer's template
+ * binding and data observation (collectively, "property effects") system.
+ *
+ * This mixin uses provides the following key static methods for adding
+ * property effects to an element class:
+ * - `addPropertyEffect`
+ * - `createPropertyObserver`
+ * - `createMethodObserver`
+ * - `createNotifyingProperty`
+ * - `createReadOnlyProperty`
+ * - `createReflectedProperty`
+ * - `createComputedProperty`
+ * - `bindTemplate`
+ *
+ * Each method creates one or more property accessors, along with metadata
+ * used by this mixin's implementation of `_propertiesChanged` to perform
+ * the property effects.
+ *
+ * Underscored versions of the above methods also exist on the element
+ * prototype for adding property effects on instances at runtime.
+ *
+ * Note that this mixin overrides several `PropertyAccessors` methods, in
+ * many cases to maintain guarantees provided by the Polymer 1.x features;
+ * notably it changes property accessors to be synchronous by default
+ * whereas the default when using `PropertyAccessors` standalone is to be
+ * async by default.
+ *
+ * @mixinFunction
+ * @polymer
+ * @appliesMixin Polymer.TemplateStamp
+ * @appliesMixin Polymer.PropertyAccessors
+ * @summary Element class mixin that provides meta-programming for Polymer's
+ * template binding and data observation system.
+ */
 export const PropertyEffects = dedupingMixin(superClass => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/mixins/template-stamp.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/template-stamp.js
@@ -82,6 +82,19 @@ function createNodeEventHandler(context, eventName, methodName) {
   return handler;
 }
 
+/**
+ * Element mixin that provides basic template parsing and stamping, including
+ * the following template-related features for stamped templates:
+ *
+ * - Declarative event listeners (`on-eventname="listener"`)
+ * - Map of node id's to stamped node instances (`this.$.id`)
+ * - Nested template content caching/removal and re-installation (performance
+ *   optimization)
+ *
+ * @mixinFunction
+ * @polymer
+ * @summary Element class mixin that provides basic template parsing and stamping
+ */
 export const TemplateStamp = dedupingMixin(superClass => {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/utils/flush.js
+++ b/fixtures/packages/polymer/expected/lib/utils/flush.js
@@ -2,6 +2,12 @@ import './boot.js';
 
 let debouncerQueue = [];
 
+/**
+ * Adds a `Polymer.Debouncer` to a list of globally flushable tasks.
+ *
+ * @param {!Polymer.Debouncer} debouncer Debouncer to enqueue
+ * @return {void}
+ */
 export const enqueueDebouncer = function(debouncer) {
   debouncerQueue.push(debouncer);
 };
@@ -20,6 +26,13 @@ function flushDebouncers() {
   return didFlush;
 }
 
+/**
+ * Forces several classes of asynchronously queued tasks to flush:
+ * - Debouncers added via `enqueueDebouncer`
+ * - ShadyDOM distribution
+ *
+ * @return {void}
+ */
 export const flush = function() {
   let shadyDOM, debouncers;
   do {

--- a/fixtures/packages/polymer/expected/lib/utils/gestures.js
+++ b/fixtures/packages/polymer/expected/lib/utils/gestures.js
@@ -927,6 +927,13 @@ register({
   }
 });
 
+/* eslint-enable valid-jsdoc */
+
+/** @deprecated */
 export const findOriginalTarget = _findOriginalTarget;
+
+/** @deprecated */
 export const add = addListener;
+
+/** @deprecated */
 export const remove = removeListener;

--- a/fixtures/packages/polymer/expected/lib/utils/html-tag.js
+++ b/fixtures/packages/polymer/expected/lib/utils/html-tag.js
@@ -44,6 +44,40 @@ function htmlValue(value) {
   }
 }
 
+/**
+ * A template literal tag that creates an HTML <template> element from the
+ * contents of the string.
+ *
+ * This allows you to write a Polymer Template in JavaScript.
+ *
+ * Templates can be composed by interpolating `HTMLTemplateElement`s in
+ * expressions in the JavaScript template literal. The nested template's
+ * `innerHTML` is included in the containing template.  The only other
+ * values allowed in expressions are those returned from `Polymer.htmlLiteral`
+ * which ensures only literal values from JS source ever reach the HTML, to
+ * guard against XSS risks.
+ *
+ * All other values are disallowed in expressions to help prevent XSS
+ * attacks; however, `Polymer.htmlLiteral` can be used to compose static
+ * string values into templates. This is useful to compose strings into
+ * places that do not accept html, like the css text of a `style`
+ * element.
+ *
+ * Example:
+ *
+ *     static get template() {
+ *       return Polymer.html`
+ *         <style>:host{ content:"..." }</style>
+ *         <div class="shadowed">${this.partialTemplate}</div>
+ *         ${super.template}
+ *       `;
+ *     }
+ *     static get partialTemplate() { return Polymer.html`<span>Partial!</span>`; }
+ *
+ * @param {!ITemplateArray} strings Constant parts of tagged template literal
+ * @param {...*} values Variable parts of tagged template literal
+ * @return {!HTMLTemplateElement} Constructed HTMLTemplateElement
+ */
 export const html = function html(strings, ...values) {
   const template = /** @type {!HTMLTemplateElement} */(document.createElement('template'));
   template.innerHTML = values.reduce((acc, v, idx) =>
@@ -51,6 +85,28 @@ export const html = function html(strings, ...values) {
   return template;
 };
 
+/**
+ * An html literal tag that can be used with `Polymer.html` to compose.
+ * a literal string.
+ *
+ * Example:
+ *
+ *     static get template() {
+ *       return Polymer.html`
+ *         <style>
+ *           :host { display: block; }
+ *           ${styleTemplate}
+ *         </style>
+ *         <div class="shadowed">${staticValue}</div>
+ *         ${super.template}
+ *       `;
+ *     }
+ *     static get styleTemplate() { return Polymer.htmlLiteral`.shadowed { background: gray; }`; }
+ *
+ * @param {!ITemplateArray} strings Constant parts of tagged template literal
+ * @param {...*} values Variable parts of tagged template literal
+ * @return {!LiteralString} Constructed literal string
+ */
 export const htmlLiteral = function(strings, ...values) {
   return new LiteralString(values.reduce((acc, v, idx) =>
       acc + literalValue(v) + strings[idx + 1], strings[0]));

--- a/fixtures/packages/polymer/expected/lib/utils/import-href.js
+++ b/fixtures/packages/polymer/expected/lib/utils/import-href.js
@@ -10,6 +10,23 @@ function whenImportsReady(cb) {
   }
 }
 
+/**
+ * Convenience method for importing an HTML document imperatively.
+ *
+ * This method creates a new `<link rel="import">` element with
+ * the provided URL and appends it to the document to start loading.
+ * In the `onload` callback, the `import` property of the `link`
+ * element will contain the imported document contents.
+ *
+ * @param {string} href URL to document to load.
+ * @param {?function(!Event):void=} onload Callback to notify when an import successfully
+ *   loaded.
+ * @param {?function(!ErrorEvent):void=} onerror Callback to notify when an import
+ *   unsuccessfully loaded.
+ * @param {boolean=} optAsync True if the import should be loaded `async`.
+ *   Defaults to `false`.
+ * @return {!HTMLLinkElement} The link element for the URL to be loaded.
+ */
 export const importHref = function(href, onload, onerror, optAsync) {
   let link = /** @type {HTMLLinkElement} */
     (document.head.querySelector('link[href="' + href + '"][import-href]'));

--- a/fixtures/packages/polymer/expected/lib/utils/mixin.js
+++ b/fixtures/packages/polymer/expected/lib/utils/mixin.js
@@ -13,6 +13,17 @@ MixinFunction.prototype.__mixinApplications;
 /** @type {(Object | undefined)} */
 MixinFunction.prototype.__mixinSet;
 
+/* eslint-disable valid-jsdoc */
+/**
+ * Wraps an ES6 class expression mixin such that the mixin is only applied
+ * if it has not already been applied its base argument. Also memoizes mixin
+ * applications.
+ *
+ * @template T
+ * @param {T} mixin ES6 class expression mixin to wrap
+ * @return {T}
+ * @suppress {invalidCasts}
+ */
 export const dedupingMixin = function(mixin) {
   let mixinApplications = /** @type {!MixinFunction} */(mixin).__mixinApplications;
   if (!mixinApplications) {
@@ -43,3 +54,4 @@ export const dedupingMixin = function(mixin) {
 
   return /** @type {T} */ (dedupingMixin);
 };
+/* eslint-enable valid-jsdoc */

--- a/fixtures/packages/polymer/expected/lib/utils/path.js
+++ b/fixtures/packages/polymer/expected/lib/utils/path.js
@@ -93,4 +93,20 @@ export function set(root, path, value) {
   return parts.join('.');
 }
 
+/**
+ * Returns true if the given string is a structured data path (has dots).
+ *
+ * This function is deprecated.  Use `Polymer.Path.isPath` instead.
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.isDeep('foo.bar.baz') // true
+ * Polymer.Path.isDeep('foo')         // false
+ * ```
+ *
+ * @deprecated
+ * @param {string} path Path string
+ * @return {boolean} True if the string contained one or more dots
+ */
 export const isDeep = isPath;

--- a/fixtures/packages/polymer/expected/lib/utils/settings.js
+++ b/fixtures/packages/polymer/expected/lib/utils/settings.js
@@ -20,6 +20,13 @@ let rootPath = undefined ||
 
 export { rootPath };
 
+/**
+ * Sets the global rootPath property used by `Polymer.ElementMixin` and
+ * available via `Polymer.rootPath`.
+ *
+ * @param {string} path The new root path
+ * @return {void}
+ */
 export const setRootPath = function(path) {
   rootPath = path;
 };
@@ -43,8 +50,15 @@ export const setRootPath = function(path) {
  */
 let sanitizeDOMValue = undefined;
 
+// This is needed for tooling
 export { sanitizeDOMValue };
 
+/**
+ * Sets the global sanitizeDOMValue available via `Polymer.sanitizeDOMValue`.
+ *
+ * @param {(function(*,string,string,Node):*)|undefined} newSanitizeDOMValue the global sanitizeDOMValue callback
+ * @return {void}
+ */
 export const setSanitizeDOMValue = function(newSanitizeDOMValue) {
   sanitizeDOMValue = newSanitizeDOMValue;
 };
@@ -61,6 +75,12 @@ let passiveTouchGestures = false;
 
 export { passiveTouchGestures };
 
+/**
+ * Sets `passiveTouchGestures` globally for all elements using Polymer Gestures.
+ *
+ * @param {boolean} usePassive enable or disable passive touch gestures globally
+ * @return {void}
+ */
 export const setPassiveTouchGestures = function(usePassive) {
   passiveTouchGestures = usePassive;
 };

--- a/fixtures/packages/polymer/expected/polymer-element.js
+++ b/fixtures/packages/polymer/expected/polymer-element.js
@@ -18,5 +18,13 @@ import { html as html$0 } from './lib/utils/html-tag.js';
  *   attribute deserialization, and property change observation
  */
 const Element = ElementMixin(HTMLElement);
+
+/**
+ * @constructor
+ * @implements {Polymer_ElementMixin}
+ * @extends {HTMLElement}
+ */
 export { Element };
+
+// NOTE: this is here for modulizer to export `html` for the module version of this file
 export { html$0 as html };

--- a/fixtures/packages/polymer/expected/polymer.js
+++ b/fixtures/packages/polymer/expected/polymer.js
@@ -8,5 +8,22 @@ import './lib/elements/array-selector.js';
 import './lib/elements/custom-style.js';
 import './lib/legacy/mutable-data-behavior.js';
 import { html as html$0 } from './lib/utils/html-tag.js';
+
+// bc
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+/* template elements */
+/* custom-style */
+/* bc behaviors */
+/* import html-tag to export html */
 export const Base = LegacyElementMixin(HTMLElement).prototype;
+
+// NOTE: this is here for modulizer to export `html` for the module version of this file
 export { html$0 as html };

--- a/src/passes/rewrite-namespace-exports.ts
+++ b/src/passes/rewrite-namespace-exports.ts
@@ -121,12 +121,12 @@ class RewriteNamespaceExportsPass {
         correctedNamespaceName = 'Polymer';
         name = 'Polymer';
       }
-      replacePreservingComments(
-          nodePath,
-          jsc.exportNamedDeclaration(jsc.variableDeclaration(
-              this.mutableNames.has(correctedNamespaceName) ? 'let' : 'const',
-              [jsc.variableDeclarator(
-                  jsc.identifier(name), exportedExpression)])));
+      const variableKind =
+          this.mutableNames.has(correctedNamespaceName) ? 'let' : 'const';
+      const newExportNode = jsc.exportNamedDeclaration(jsc.variableDeclaration(
+          variableKind,
+          [jsc.variableDeclarator(jsc.identifier(name), exportedExpression)]));
+      replacePreservingComments(nodePath, newExportNode);
       this.exportMigrationRecords.push(
           {oldNamespacedName: correctedNamespaceName, es6ExportName: name});
     }

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -125,7 +125,7 @@ suite('AnalysisConverter', () => {
 
     function assertSources(
         results: Map<string, string|undefined>,
-        expected: {[path: string]: string | undefined}) {
+        expected: {[path: string]: string|undefined}) {
       for (const [expectedPath, expectedContents] of Object.entries(expected)) {
         assert.isTrue(
             results.has(expectedPath),
@@ -910,10 +910,14 @@ export function increment() {
       });
       assertSources(await convert(), {
         'test.js': `
+/**
+               */
 export const dom = function() {
   return 'Polymer.dom result';
 };
 
+/**
+               */
 export const subFn = function() {
   return 'Polymer.dom.subFn result';
 };
@@ -943,6 +947,8 @@ export const subFn = function() {
       });
       assertSources(await convert(), {
         'test.js': `
+/**
+               */
 export let subFn = function() {
   subFn = () => 42;
 };
@@ -982,14 +988,20 @@ export let subFn = function() {
       });
       assertSources(await convert(), {
         'test.js': `
+/**
+               */
 export const dom = function() {
   return 'Polymer.dom result';
 };
 
+/**
+               */
 export const subFn = function() {
   return 'Polymer.dom.subFn result';
 };
 
+/**
+               */
 export const subFnDelegate = function() {
   return 'Polymer.dom.subFnDelegate delegates: ' + dom() + subFn();
 };
@@ -2947,6 +2959,52 @@ console.log('second script');
 /* Second comment */
 /* Final trailing comment */
 ;
+`,
+      });
+    });
+
+    testName = 'copy over behavior comments properly';
+    test(testName, async () => {
+      setSources({
+        'test.html': `
+          <script>
+            /**
+             * This is a long and important comment.
+             * It has much info.
+             * @memberof Polymer This line should be removed
+             * @polymerBehavior
+             */
+            Polymer.MyBehavior = {};
+
+            /**
+             * This comment is also important, but its
+             * whitespace is handled better, because it doesn't
+             * have any lines that need filtering out.
+             * @polymer
+             * @mixinFunction
+             */
+            Polymer.MyMixinFunction = function() {};
+          </script>
+        `
+      });
+
+      assertSources(await convert(), {
+        'test.js': `
+/**
+             * This is a long and important comment.
+             * It has much info.
+             * @polymerBehavior
+             */
+export const MyBehavior = {};
+
+/**
+ * This comment is also important, but its
+ * whitespace is handled better, because it doesn't
+ * have any lines that need filtering out.
+ * @polymer
+ * @mixinFunction
+ */
+export const MyMixinFunction = function() {};
 `,
       });
     });

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -910,14 +910,10 @@ export function increment() {
       });
       assertSources(await convert(), {
         'test.js': `
-/**
-               */
 export const dom = function() {
   return 'Polymer.dom result';
 };
 
-/**
-               */
 export const subFn = function() {
   return 'Polymer.dom.subFn result';
 };
@@ -947,8 +943,6 @@ export const subFn = function() {
       });
       assertSources(await convert(), {
         'test.js': `
-/**
-               */
 export let subFn = function() {
   subFn = () => 42;
 };
@@ -988,20 +982,14 @@ export let subFn = function() {
       });
       assertSources(await convert(), {
         'test.js': `
-/**
-               */
 export const dom = function() {
   return 'Polymer.dom result';
 };
 
-/**
-               */
 export const subFn = function() {
   return 'Polymer.dom.subFn result';
 };
 
-/**
-               */
 export const subFnDelegate = function() {
   return 'Polymer.dom.subFnDelegate delegates: ' + dom() + subFn();
 };
@@ -2991,10 +2979,10 @@ console.log('second script');
       assertSources(await convert(), {
         'test.js': `
 /**
-             * This is a long and important comment.
-             * It has much info.
-             * @polymerBehavior
-             */
+ * This is a long and important comment.
+ * It has much info.
+ * @polymerBehavior
+ */
 export const MyBehavior = {};
 
 /**


### PR DESCRIPTION
Analyzing and linting polymer 3 sources was having lots of issues due to load-bearing-comments being missing.