### PR TITLE
Package type

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,9 @@
         "3.0.0",
         "--out",
         "${workspaceFolder}/debug-output",
-        "--force"
+        "--force",
+        "--package-type",
+        "element"
       ]
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,9 +17,7 @@
         "3.0.0",
         "--out",
         "${workspaceFolder}/debug-output",
-        "--force",
-        "--package-type",
-        "element"
+        "--force"
       ]
     }
   ]

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -17,7 +17,6 @@ import * as path from 'path';
 import * as semver from 'semver';
 
 import {CliOptions} from '../cli';
-import {PackageType} from '../conversion-settings';
 import convertPackage from '../convert-package';
 import {saveDependencyMapping} from '../package-manifest';
 import {exec, logStep} from '../util';

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -51,7 +51,8 @@ export default async function run(options: CliOptions) {
 
   // TODO: each file is not always needed, refactor to optimize loading
   let inBowerJson:
-      {name: string, version: string, main: any, packageType: string}|undefined;
+      {name: string, version: string, main: any, packageType: PackageType}|
+      undefined;
   let inPackageJson: {name: string, version: string, packageType: PackageType}|
       undefined;
   let outPackageJson: {name: string, version: string, packageType: PackageType}|

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -78,9 +78,6 @@ export default async function run(options: CliOptions) {
   let npmPackageName = options['npm-name'] ||
       inPackageJson && inPackageJson.name ||
       outPackageJson && outPackageJson.name;
-  let packageType = options['package-type'] ||
-      inPackageJson && inPackageJson.packageType ||
-      outPackageJson && outPackageJson.packageType;
   let npmPackageVersion = options['npm-version'] ||
       inPackageJson && inPackageJson.version ||
       outPackageJson && outPackageJson.version;
@@ -94,22 +91,6 @@ export default async function run(options: CliOptions) {
                        message: 'npm package name?',
                        default: inBowerJson && `@polymer/${inBowerJson.name}`,
                      }]))['npm-name'] as string;
-  }
-
-  if (typeof packageType !== 'string') {
-    packageType = (await inquirer.prompt([{
-                    type: 'list',
-                    name: 'package-type',
-                    message: 'is this an element or an application?',
-                    choices: ['element', 'application']
-                  }]))['package-type'] as PackageType;
-  } else {
-    if (packageType && packageType !== 'element' &&
-        packageType !== 'application') {
-      throw new Error(
-          `package-type "${packageType}" is not supported. ` +
-          `Supported types: "element", "application".`);
-    }
   }
 
   if (typeof npmPackageVersion !== 'string') {
@@ -137,7 +118,7 @@ export default async function run(options: CliOptions) {
     addImportPath: options['add-import-path'],
     flat: options.flat,
     private: options.private,
-    packageType: packageType
+    packageType: options['package-type']
   });
 
   logStep(2, 2, '🎉', `Conversion Complete!`);

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -50,13 +50,9 @@ export default async function run(options: CliOptions) {
   }
 
   // TODO: each file is not always needed, refactor to optimize loading
-  let inBowerJson:
-      {name: string, version: string, main: any, packageType: PackageType}|
-      undefined;
-  let inPackageJson: {name: string, version: string, packageType: PackageType}|
-      undefined;
-  let outPackageJson: {name: string, version: string, packageType: PackageType}|
-      undefined;
+  let inBowerJson: {name: string, version: string, main: any}|undefined;
+  let inPackageJson: {name: string, version: string}|undefined;
+  let outPackageJson: {name: string, version: string}|undefined;
   try {
     outPackageJson = await fse.readJSON(path.join(outDir, 'package.json'));
   } catch (e) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,7 +13,7 @@
  */
 
 import * as commandLineArgs from 'command-line-args';
-import {NpmImportStyle} from '../conversion-settings';
+import {NpmImportStyle, PackageType} from '../conversion-settings';
 
 import runPackageCommand from './command-package';
 import runWorkspaceCommand from './command-workspace';
@@ -178,6 +178,12 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
     description:
         `Whether to set private:true in the newly generated package.json.`,
   },
+  {
+    name: 'package-type',
+    type: String,
+    description:
+        `[element|application] The type of package that is to be modulized`,
+  },
 ];
 
 export interface CliOptions {
@@ -204,6 +210,7 @@ export interface CliOptions {
   'add-import-path': boolean;
   flat: boolean;
   'private': boolean;
+  'package-type': PackageType;
 }
 
 export async function run() {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -181,8 +181,10 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
   {
     name: 'package-type',
     type: String,
+    defaultValue: 'element',
     description:
-        `[element|application] The type of package that is to be modulized`,
+        `[element|application] The type of package that is to be modulized. ` +
+        `Defaults to "element"`,
   },
 ];
 
@@ -253,6 +255,13 @@ installation.
     throw new Error(
         `import-style "${importStyle}" not supported. ` +
         `Supported styles: "name", "path".`);
+  }
+
+  const packageType = options['package-type'];
+  if (packageType !== 'element' && packageType !== 'application') {
+    throw new Error(
+        `package-type "${packageType}" is not supported. ` +
+        `Supported types: "element", "application".`);
   }
 
   await runPackageCommand(options);

--- a/src/conversion-settings.ts
+++ b/src/conversion-settings.ts
@@ -20,6 +20,7 @@ import {Analysis} from 'polymer-analyzer';
 import {OriginalDocumentUrl} from './urls/types';
 
 export type NpmImportStyle = 'name'|'path';
+export type PackageType = 'element'|'application';
 
 /**
  * These are the settings used to configure the conversion. It contains

--- a/src/convert-package.ts
+++ b/src/convert-package.ts
@@ -36,7 +36,7 @@ import {deleteGlobsSafe, mkdirp, readJsonIfExists, rimraf, writeFileResults} fro
 export interface PackageConversionSettings extends PartialConversionSettings {
   readonly packageName: string;
   readonly packageVersion: string;
-  readonly packageType?: PackageType;
+  readonly packageType: PackageType;
   readonly inDir: string;
   readonly outDir: string;
   readonly cleanOutDir?: boolean;

--- a/src/urls/package-url-handler.ts
+++ b/src/urls/package-url-handler.ts
@@ -49,7 +49,7 @@ export class PackageUrlHandler implements UrlHandler {
 
   constructor(
       analyzer: Analyzer, bowerPackageName: string, npmPackageName: string,
-      packageType: PackageType = 'element', packageDir: string) {
+      packageType: PackageType, packageDir: string) {
     this.analyzer = analyzer;
     this.bowerPackageName = bowerPackageName;
     this.npmPackageName = npmPackageName;


### PR DESCRIPTION
Fixes #206

We seem to have been ignoring the type of project we are trying to modulize. This affects whether it's a relative path out of the package or into `node_modules`. This can be set via the `--package-type` flag which defaults to `element`.

I had it as a mandatory flag where it would ask you to choose between element and application but I changed my mind because I personally didn't like having to type it in every time. LMK if I should bring it back.

CC @notwaldorf 