### PR TITLE
Handle namespace export comments better.

### DIFF
--- a/fixtures/packages/polymer/expected/lib/mixins/element-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/element-mixin.js
@@ -650,18 +650,54 @@ export const ElementMixin = dedupingMixin(base => {
   return PolymerElement;
 });
 
+/**
+ * Provides basic tracking of element definitions (registrations) and
+ * instance counts.
+ *
+ * @summary Provides basic tracking of element definitions (registrations) and
+ * instance counts.
+ */
+`TODO(modulizer): A namespace named Polymer.telemetry was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
+/**
+ * Total number of Polymer element instances created.
+ * @type {number}
+ */
 export let instanceCount = 0;
+
+/**
+ * Array of Polymer element classes that have been finalized.
+ * @type {Array<Polymer.Element>}
+ */
 export const registrations = [];
 
+/**
+ * @param {!PolymerElementConstructor} prototype Element prototype to log
+ * @this {this}
+ * @private
+ */
 export function _regLog(prototype) {
   console.log('[' + prototype.is + ']: registered');
 }
 
+/**
+ * Registers a class prototype for telemetry purposes.
+ * @param {HTMLElement} prototype Element prototype to register
+ * @this {this}
+ * @protected
+ */
 export function register(prototype) {
   registrations.push(prototype);
   undefined && _regLog(prototype);
 }
 
+/**
+ * Logs all elements registered with an `is` to the console.
+ * @public
+ * @this {this}
+ */
 export function dumpRegistrations() {
   registrations.forEach(_regLog);
 }

--- a/fixtures/packages/polymer/expected/lib/mixins/element-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/element-mixin.js
@@ -658,7 +658,7 @@ export const ElementMixin = dedupingMixin(base => {
  * instance counts.
  */
 `TODO(modulizer): A namespace named Polymer.telemetry was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/array-splice.js
+++ b/fixtures/packages/polymer/expected/lib/utils/array-splice.js
@@ -262,7 +262,7 @@ function equals(currentValue, previousValue) {
  * @summary Module that provides utilities for diffing arrays.
  */
 `TODO(modulizer): A namespace named Polymer.ArraySplice was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/array-splice.js
+++ b/fixtures/packages/polymer/expected/lib/utils/array-splice.js
@@ -258,4 +258,42 @@ function equals(currentValue, previousValue) {
   return currentValue === previousValue;
 }
 
+/**
+ * @summary Module that provides utilities for diffing arrays.
+ */
+`TODO(modulizer): A namespace named Polymer.ArraySplice was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
+/**
+ * Returns an array of splice records indicating the minimum edits required
+ * to transform the `previous` array into the `current` array.
+ *
+ * Splice records are ordered by index and contain the following fields:
+ * - `index`: index where edit started
+ * - `removed`: array of removed items from this index
+ * - `addedCount`: number of items added at this index
+ *
+ * This function is based on the Levenshtein "minimum edit distance"
+ * algorithm. Note that updates are treated as removal followed by addition.
+ *
+ * The worst-case time complexity of this algorithm is `O(l * p)`
+ *   l: The length of the current array
+ *   p: The length of the previous array
+ *
+ * However, the worst-case complexity is reduced by an `O(n)` optimization
+ * to detect any shared prefix & suffix between the two arrays and only
+ * perform the more expensive minimum edit distance calculation over the
+ * non-shared portions of the arrays.
+ *
+ * @function
+ * @param {!Array} current The "changed" array for which splices will be
+ * calculated.
+ * @param {!Array} previous The "unchanged" original array to compare
+ * `current` against to determine the splices.
+ * @return {!Array} Returns an array of splice record objects. Each of these
+ * contains: `index` the location where the splice occurred; `removed`
+ * the array of removed items from this location; `addedCount` the number
+ * of items added at this location.
+ */
 export { calculateSplices };

--- a/fixtures/packages/polymer/expected/lib/utils/async.js
+++ b/fixtures/packages/polymer/expected/lib/utils/async.js
@@ -24,6 +24,24 @@ function microtaskFlush() {
   microtaskLastHandle += len;
 }
 
+/**
+ * Module that provides a number of strategies for enqueuing asynchronous
+ * tasks.  Each sub-module provides a standard `run(fn)` interface that returns a
+ * handle, and a `cancel(handle)` interface for canceling async tasks before
+ * they run.
+ *
+ * @summary Module that provides a number of strategies for enqueuing asynchronous
+ * tasks.
+ */
+`TODO(modulizer): A namespace named Polymer.Async was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
+/**
+ * Async interface wrapper around `setTimeout`.
+ *
+ * @summary Async interface wrapper around `setTimeout`.
+ */
 export const timeOut = {
   /**
    * Returns a sub-module with the async interface providing the provided
@@ -64,6 +82,11 @@ export const timeOut = {
   }
 };
 
+/**
+ * Async interface wrapper around `requestAnimationFrame`.
+ *
+ * @summary Async interface wrapper around `requestAnimationFrame`.
+ */
 export const animationFrame = {
   /**
    * Enqueues a function called at `requestAnimationFrame` timing.
@@ -87,6 +110,12 @@ export const animationFrame = {
   }
 };
 
+/**
+ * Async interface wrapper around `requestIdleCallback`.  Falls back to
+ * `setTimeout` on browsers that do not support `requestIdleCallback`.
+ *
+ * @summary Async interface wrapper around `requestIdleCallback`.
+ */
 export const idlePeriod = {
   /**
    * Enqueues a function called at `requestIdleCallback` timing.
@@ -114,6 +143,18 @@ export const idlePeriod = {
   }
 };
 
+/**
+ * Async interface for enqueuing callbacks that run at microtask timing.
+ *
+ * Note that microtask timing is achieved via a single `MutationObserver`,
+ * and thus callbacks enqueued with this API will all run in a single
+ * batch, and not interleaved with other microtasks such as promises.
+ * Promises are avoided as an implementation choice for the time being
+ * due to Safari bugs that cause Promises to lack microtask guarantees.
+ *
+ * @summary Async interface for enqueuing callbacks that run at microtask
+ *   timing.
+ */
 export const microTask = {
 
   /**

--- a/fixtures/packages/polymer/expected/lib/utils/async.js
+++ b/fixtures/packages/polymer/expected/lib/utils/async.js
@@ -34,7 +34,7 @@ function microtaskFlush() {
  * tasks.
  */
 `TODO(modulizer): A namespace named Polymer.Async was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/case-map.js
+++ b/fixtures/packages/polymer/expected/lib/utils/case-map.js
@@ -4,6 +4,24 @@ const caseMap = {};
 const DASH_TO_CAMEL = /-[a-z]/g;
 const CAMEL_TO_DASH = /([A-Z])/g;
 
+/**
+ * Module with utilities for converting between "dash-case" and "camelCase"
+ * identifiers.
+ *
+ * @summary Module that provides utilities for converting between "dash-case"
+ *   and "camelCase".
+ */
+`TODO(modulizer): A namespace named Polymer.CaseMap was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
+/**
+ * Converts "dash-case" identifier (e.g. `foo-bar-baz`) to "camelCase"
+ * (e.g. `fooBarBaz`).
+ *
+ * @param {string} dash Dash-case identifier
+ * @return {string} Camel-case representation of the identifier
+ */
 export function dashToCamelCase(dash) {
   return caseMap[dash] || (
     caseMap[dash] = dash.indexOf('-') < 0 ? dash : dash.replace(DASH_TO_CAMEL,
@@ -12,6 +30,13 @@ export function dashToCamelCase(dash) {
   );
 }
 
+/**
+ * Converts "camelCase" identifier (e.g. `fooBarBaz`) to "dash-case"
+ * (e.g. `foo-bar-baz`).
+ *
+ * @param {string} camel Camel-case identifier
+ * @return {string} Dash-case representation of the identifier
+ */
 export function camelToDashCase(camel) {
   return caseMap[camel] || (
     caseMap[camel] = camel.replace(CAMEL_TO_DASH, '-$1').toLowerCase()

--- a/fixtures/packages/polymer/expected/lib/utils/case-map.js
+++ b/fixtures/packages/polymer/expected/lib/utils/case-map.js
@@ -12,7 +12,7 @@ const CAMEL_TO_DASH = /([A-Z])/g;
  *   and "camelCase".
  */
 `TODO(modulizer): A namespace named Polymer.CaseMap was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/gestures.js
+++ b/fixtures/packages/polymer/expected/lib/utils/gestures.js
@@ -323,7 +323,7 @@ document.addEventListener('touchend', ignoreMouse, SUPPORTS_PASSIVE ? {passive: 
  * @summary Module for adding cross-platform gesture event listeners.
  */
 `TODO(modulizer): A namespace named Polymer.Gestures was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 export const gestures = {};

--- a/fixtures/packages/polymer/expected/lib/utils/path.js
+++ b/fixtures/packages/polymer/expected/lib/utils/path.js
@@ -1,9 +1,44 @@
 import './boot.js';
 
+/**
+ * Module with utilities for manipulating structured data path strings.
+ *
+ * @summary Module with utilities for manipulating structured data path strings.
+ */
+`TODO(modulizer): A namespace named Polymer.Path was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
+/**
+ * Returns true if the given string is a structured data path (has dots).
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.isPath('foo.bar.baz') // true
+ * Polymer.Path.isPath('foo')         // false
+ * ```
+ *
+ * @param {string} path Path string
+ * @return {boolean} True if the string contained one or more dots
+ */
 export function isPath(path) {
   return path.indexOf('.') >= 0;
 }
 
+/**
+ * Returns the root property name for the given path.
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.root('foo.bar.baz') // 'foo'
+ * Polymer.Path.root('foo')         // 'foo'
+ * ```
+ *
+ * @param {string} path Path string
+ * @return {string} Root property name
+ */
 export function root(path) {
   let dotIndex = path.indexOf('.');
   if (dotIndex === -1) {
@@ -12,26 +47,94 @@ export function root(path) {
   return path.slice(0, dotIndex);
 }
 
+/**
+ * Given `base` is `foo.bar`, `foo` is an ancestor, `foo.bar` is not
+ * Returns true if the given path is an ancestor of the base path.
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.isAncestor('foo.bar', 'foo')         // true
+ * Polymer.Path.isAncestor('foo.bar', 'foo.bar')     // false
+ * Polymer.Path.isAncestor('foo.bar', 'foo.bar.baz') // false
+ * ```
+ *
+ * @param {string} base Path string to test against.
+ * @param {string} path Path string to test.
+ * @return {boolean} True if `path` is an ancestor of `base`.
+ */
 export function isAncestor(base, path) {
   //     base.startsWith(path + '.');
   return base.indexOf(path + '.') === 0;
 }
 
+/**
+ * Given `base` is `foo.bar`, `foo.bar.baz` is an descendant
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.isDescendant('foo.bar', 'foo.bar.baz') // true
+ * Polymer.Path.isDescendant('foo.bar', 'foo.bar')     // false
+ * Polymer.Path.isDescendant('foo.bar', 'foo')         // false
+ * ```
+ *
+ * @param {string} base Path string to test against.
+ * @param {string} path Path string to test.
+ * @return {boolean} True if `path` is a descendant of `base`.
+ */
 export function isDescendant(base, path) {
   //     path.startsWith(base + '.');
   return path.indexOf(base + '.') === 0;
 }
 
+/**
+ * Replaces a previous base path with a new base path, preserving the
+ * remainder of the path.
+ *
+ * User must ensure `path` has a prefix of `base`.
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.translate('foo.bar', 'zot', 'foo.bar.baz') // 'zot.baz'
+ * ```
+ *
+ * @param {string} base Current base string to remove
+ * @param {string} newBase New base string to replace with
+ * @param {string} path Path to translate
+ * @return {string} Translated string
+ */
 export function translate(base, newBase, path) {
   return newBase + path.slice(base.length);
 }
 
+/**
+ * @param {string} base Path string to test against
+ * @param {string} path Path string to test
+ * @return {boolean} True if `path` is equal to `base`
+ * @this {Path}
+ */
 export function matches(base, path) {
   return (base === path) ||
          isAncestor(base, path) ||
          isDescendant(base, path);
 }
 
+/**
+ * Converts array-based paths to flattened path.  String-based paths
+ * are returned as-is.
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.normalize(['foo.bar', 0, 'baz'])  // 'foo.bar.0.baz'
+ * Polymer.Path.normalize('foo.bar.0.baz')        // 'foo.bar.0.baz'
+ * ```
+ *
+ * @param {string | !Array<string|number>} path Input path
+ * @return {string} Flattened path
+ */
 export function normalize(path) {
   if (Array.isArray(path)) {
     let parts = [];
@@ -47,6 +150,22 @@ export function normalize(path) {
   }
 }
 
+/**
+ * Splits a path into an array of property names. Accepts either arrays
+ * of path parts or strings.
+ *
+ * Example:
+ *
+ * ```
+ * Polymer.Path.split(['foo.bar', 0, 'baz'])  // ['foo', 'bar', '0', 'baz']
+ * Polymer.Path.split('foo.bar.0.baz')        // ['foo', 'bar', '0', 'baz']
+ * ```
+ *
+ * @param {string | !Array<string|number>} path Input path
+ * @return {!Array<string>} Array of path parts
+ * @this {Path}
+ * @suppress {checkTypes}
+ */
 export function split(path) {
   if (Array.isArray(path)) {
     return normalize(path).split('.');
@@ -54,6 +173,18 @@ export function split(path) {
   return path.toString().split('.');
 }
 
+/**
+ * Reads a value from a path.  If any sub-property in the path is `undefined`,
+ * this method returns `undefined` (will never throw.
+ *
+ * @param {Object} root Object from which to dereference path from
+ * @param {string | !Array<string|number>} path Path to read
+ * @param {Object=} info If an object is provided to `info`, the normalized
+ *  (flattened) path will be set to `info.path`.
+ * @return {*} Value at path, or `undefined` if the path could not be
+ *  fully dereferenced.
+ * @this {Path}
+ */
 export function get(root, path, info) {
   let prop = root;
   let parts = split(path);
@@ -71,6 +202,16 @@ export function get(root, path, info) {
   return prop;
 }
 
+/**
+ * Sets a value to a path.  If any sub-property in the path is `undefined`,
+ * this method will no-op.
+ *
+ * @param {Object} root Object from which to dereference path from
+ * @param {string | !Array<string|number>} path Path to set
+ * @param {*} value Value to set to path
+ * @return {string | undefined} The normalized version of the input path
+ * @this {Path}
+ */
 export function set(root, path, value) {
   let prop = root;
   let parts = split(path);

--- a/fixtures/packages/polymer/expected/lib/utils/path.js
+++ b/fixtures/packages/polymer/expected/lib/utils/path.js
@@ -6,7 +6,7 @@ import './boot.js';
  * @summary Module with utilities for manipulating structured data path strings.
  */
 `TODO(modulizer): A namespace named Polymer.Path was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/render-status.js
+++ b/fixtures/packages/polymer/expected/lib/utils/render-status.js
@@ -56,7 +56,7 @@ function flush() {
  * @summary Module for scheduling flushable pre-render and post-render tasks.
  */
 `TODO(modulizer): A namespace named Polymer.RenderStatus was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/render-status.js
+++ b/fixtures/packages/polymer/expected/lib/utils/render-status.js
@@ -50,6 +50,30 @@ function flush() {
   scheduled = false;
 }
 
+/**
+ * Module for scheduling flushable pre-render and post-render tasks.
+ *
+ * @summary Module for scheduling flushable pre-render and post-render tasks.
+ */
+`TODO(modulizer): A namespace named Polymer.RenderStatus was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
+/**
+ * Enqueues a callback which will be run before the next render, at
+ * `requestAnimationFrame` timing.
+ *
+ * This method is useful for enqueuing work that requires DOM measurement,
+ * since measurement may not be reliable in custom element callbacks before
+ * the first render, as well as for batching measurement tasks in general.
+ *
+ * Tasks in this queue may be flushed by calling `Polymer.RenderStatus.flush()`.
+ *
+ * @param {*} context Context object the callback function will be bound to
+ * @param {function(...*):void} callback Callback function
+ * @param {!Array=} args An array of arguments to call the callback function with
+ * @return {void}
+ */
 export function beforeNextRender(context, callback, args) {
   if (!scheduled) {
     schedule();
@@ -57,6 +81,20 @@ export function beforeNextRender(context, callback, args) {
   beforeRenderQueue.push([context, callback, args]);
 }
 
+/**
+ * Enqueues a callback which will be run after the next render, equivalent
+ * to one task (`setTimeout`) after the next `requestAnimationFrame`.
+ *
+ * This method is useful for tuning the first-render performance of an
+ * element or application by deferring non-critical work until after the
+ * first paint.  Typical non-render-critical work may include adding UI
+ * event listeners and aria attributes.
+ *
+ * @param {*} context Context object the callback function will be bound to
+ * @param {function(...*):void} callback Callback function
+ * @param {!Array=} args An array of arguments to call the callback function with
+ * @return {void}
+ */
 export function afterNextRender(context, callback, args) {
   if (!scheduled) {
     schedule();
@@ -64,4 +102,10 @@ export function afterNextRender(context, callback, args) {
   afterRenderQueue.push([context, callback, args]);
 }
 
+/**
+ * Flushes all `beforeNextRender` tasks, followed by all `afterNextRender`
+ * tasks.
+ *
+ * @return {void}
+ */
 export { flush };

--- a/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
+++ b/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
@@ -6,7 +6,7 @@ let workingURL;
 let resolveDoc;
 /**
  * Resolves the given URL against the provided `baseUri'.
- *
+ * 
  * Note that this function performs no resolution for URLs that start
  * with `/` (absolute URLs) or `#` (hash identifiers).  For general purpose
  * URL resolution, use `window.URL`.

--- a/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
+++ b/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
@@ -80,6 +80,15 @@ function pathFromUrl(url) {
   return url.substring(0, url.lastIndexOf('/') + 1);
 }
 
+/**
+ * Module with utilities for resolving relative URL's.
+ *
+ * @summary Module with utilities for resolving relative URL's.
+ */
+`TODO(modulizer): A namespace named Polymer.ResolveUrl was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
 export { resolveCss };
 export { resolveUrl };
 export { pathFromUrl };

--- a/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
+++ b/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
@@ -6,7 +6,7 @@ let workingURL;
 let resolveDoc;
 /**
  * Resolves the given URL against the provided `baseUri'.
- * 
+ *
  * Note that this function performs no resolution for URLs that start
  * with `/` (absolute URLs) or `#` (hash identifiers).  For general purpose
  * URL resolution, use `window.URL`.
@@ -86,7 +86,7 @@ function pathFromUrl(url) {
  * @summary Module with utilities for resolving relative URL's.
  */
 `TODO(modulizer): A namespace named Polymer.ResolveUrl was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 export { resolveCss };

--- a/fixtures/packages/polymer/expected/lib/utils/style-gather.js
+++ b/fixtures/packages/polymer/expected/lib/utils/style-gather.js
@@ -27,6 +27,24 @@ function styleForImport(importDoc) {
 /** @typedef {{assetpath: string}} */
 let templateWithAssetPath; // eslint-disable-line no-unused-vars
 
+/**
+ * Module with utilities for collection CSS text from `<templates>`, external
+ * stylesheets, and `dom-module`s.
+ *
+ * @summary Module with utilities for collection CSS text from various sources.
+ */
+`TODO(modulizer): A namespace named Polymer.StyleGather was
+declared here. The above comments should be reviewed,
+and this string can then be deleted`;
+
+/**
+ * Returns a list of <style> elements in a space-separated list of `dom-module`s.
+ *
+ * @param {string} moduleIds List of dom-module id's within which to
+ * search for css.
+ * @return {!Array<!HTMLStyleElement>} Array of contained <style> elements
+ * @this {StyleGather}
+ */
 export function stylesFromModules(moduleIds) {
  const modules = moduleIds.trim().split(/\s+/);
  const styles = [];
@@ -36,6 +54,16 @@ export function stylesFromModules(moduleIds) {
  return styles;
 }
 
+/**
+ * Returns a list of <style> elements in a given `dom-module`.
+ * Styles in a `dom-module` can come either from `<style>`s within the
+ * first `<template>`, or else from one or more
+ * `<link rel="import" type="css">` links outside the template.
+ *
+ * @param {string} moduleId dom-module id to gather styles from
+ * @return {!Array<!HTMLStyleElement>} Array of contained styles.
+ * @this {StyleGather}
+ */
 export function stylesFromModule(moduleId) {
   const m = importModule(moduleId);
 
@@ -61,6 +89,14 @@ export function stylesFromModule(moduleId) {
   return m._styles;
 }
 
+/**
+ * Returns the `<style>` elements within a given template.
+ *
+ * @param {!HTMLTemplateElement} template Template to gather styles from
+ * @param {string} baseURI baseURI for style content
+ * @return {!Array<!HTMLStyleElement>} Array of styles
+ * @this {StyleGather}
+ */
 export function stylesFromTemplate(template, baseURI) {
   if (!template._styles) {
     const styles = [];
@@ -86,11 +122,23 @@ export function stylesFromTemplate(template, baseURI) {
   return template._styles;
 }
 
+/**
+ * Returns a list of <style> elements  from stylesheets loaded via `<link rel="import" type="css">` links within the specified `dom-module`.
+ *
+ * @param {string} moduleId Id of `dom-module` to gather CSS from
+ * @return {!Array<!HTMLStyleElement>} Array of contained styles.
+ * @this {StyleGather}
+ */
 export function stylesFromModuleImports(moduleId) {
  let m = importModule(moduleId);
  return m ? _stylesFromModuleImports(m) : [];
 }
 
+/**
+ * @this {StyleGather}
+ * @param {!HTMLElement} module dom-module element that could contain `<link rel="import" type="css">` styles
+ * @return {!Array<!HTMLStyleElement>} Array of contained styles
+ */
 export function _stylesFromModuleImports(module) {
   const styles = [];
   const p$ = module.querySelectorAll(MODULE_STYLE_LINK_SELECTOR);
@@ -112,6 +160,17 @@ export function _stylesFromModuleImports(module) {
   return styles;
 }
 
+/**
+ *
+ * Returns CSS text of styles in a space-separated list of `dom-module`s.
+ * Note: This method is deprecated, use `stylesFromModules` instead.
+ *
+ * @deprecated
+ * @param {string} moduleIds List of dom-module id's within which to
+ * search for css.
+ * @return {string} Concatenated CSS content from specified `dom-module`s
+ * @this {StyleGather}
+ */
 export function cssFromModules(moduleIds) {
  let modules = moduleIds.trim().split(/\s+/);
  let cssText = '';
@@ -121,6 +180,20 @@ export function cssFromModules(moduleIds) {
  return cssText;
 }
 
+/**
+ * Returns CSS text of styles in a given `dom-module`.  CSS in a `dom-module`
+ * can come either from `<style>`s within the first `<template>`, or else
+ * from one or more `<link rel="import" type="css">` links outside the
+ * template.
+ *
+ * Any `<styles>` processed are removed from their original location.
+ * Note: This method is deprecated, use `styleFromModule` instead.
+ *
+ * @deprecated
+ * @param {string} moduleId dom-module id to gather styles from
+ * @return {string} Concatenated CSS content from specified `dom-module`
+ * @this {StyleGather}
+ */
 export function cssFromModule(moduleId) {
   let m = importModule(moduleId);
   if (m && m._cssText === undefined) {
@@ -140,6 +213,18 @@ export function cssFromModule(moduleId) {
   return m && m._cssText || '';
 }
 
+/**
+ * Returns CSS text of `<styles>` within a given template.
+ *
+ * Any `<styles>` processed are removed from their original location.
+ * Note: This method is deprecated, use `styleFromTemplate` instead.
+ *
+ * @deprecated
+ * @param {!HTMLTemplateElement} template Template to gather styles from
+ * @param {string} baseURI Base URI to resolve the URL against
+ * @return {string} Concatenated CSS content from specified template
+ * @this {StyleGather}
+ */
 export function cssFromTemplate(template, baseURI) {
   let cssText = '';
   const e$ = stylesFromTemplate(template, baseURI);
@@ -154,11 +239,29 @@ export function cssFromTemplate(template, baseURI) {
   return cssText;
 }
 
+/**
+ * Returns CSS text from stylesheets loaded via `<link rel="import" type="css">`
+ * links within the specified `dom-module`.
+ *
+ * Note: This method is deprecated, use `stylesFromModuleImports` instead.
+ *
+ * @deprecated
+ *
+ * @param {string} moduleId Id of `dom-module` to gather CSS from
+ * @return {string} Concatenated CSS content from links in specified `dom-module`
+ * @this {StyleGather}
+ */
 export function cssFromModuleImports(moduleId) {
   let m = importModule(moduleId);
   return m ? _cssFromModuleImports(m) : '';
 }
 
+/**
+ * @deprecated
+ * @this {StyleGather}
+ * @param {!HTMLElement} module dom-module element that could contain `<link rel="import" type="css">` styles
+ * @return {string} Concatenated CSS content from links in the dom-module
+ */
 export function _cssFromModuleImports(module) {
  let cssText = '';
  let styles = _stylesFromModuleImports(module);

--- a/fixtures/packages/polymer/expected/lib/utils/style-gather.js
+++ b/fixtures/packages/polymer/expected/lib/utils/style-gather.js
@@ -34,7 +34,7 @@ let templateWithAssetPath; // eslint-disable-line no-unused-vars
  * @summary Module with utilities for collection CSS text from various sources.
  */
 `TODO(modulizer): A namespace named Polymer.StyleGather was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/templatize.js
+++ b/fixtures/packages/polymer/expected/lib/utils/templatize.js
@@ -407,7 +407,7 @@ function createNotifyHostPropEffect() {
  *   utilizing Polymer templating features.
  */
 `TODO(modulizer): A namespace named Polymer.Templatize was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted`;
 
 /**

--- a/src/passes/rewrite-namespace-exports.ts
+++ b/src/passes/rewrite-namespace-exports.ts
@@ -176,7 +176,7 @@ class RewriteNamespaceExportsPass {
     if (nodePathComments.length > 0) {
       const message =
           `TODO(modulizer): A namespace named ${fullyQualifiedName} was\n` +
-          `declared here. The above comments should be reviewed,\n` +
+          `declared here. The surrounding comments should be reviewed,\n` +
           `and this string can then be deleted`;
       const tombstone = jsc.expressionStatement(jsc.templateLiteral(
           [jsc.templateElement({raw: message, cooked: message}, true)], []));

--- a/src/passes/rewrite-namespace-exports.ts
+++ b/src/passes/rewrite-namespace-exports.ts
@@ -171,7 +171,18 @@ class RewriteNamespaceExportsPass {
         getNamespaceExports(body, this.mutableNames, fullyQualifiedName);
 
     // Replace nodePath with some number of namespace exports. Easiest way
-    // is to insert the exports before nodePath, then remove nodePath.
+    // is to insert the exports after nodePath, then remove nodePath.
+    const nodePathComments = getComments(nodePath);
+    if (nodePathComments.length > 0) {
+      const message =
+          `TODO(modulizer): A namespace named ${fullyQualifiedName} was\n` +
+          `declared here. The above comments should be reviewed,\n` +
+          `and this string can then be deleted`;
+      const tombstone = jsc.expressionStatement(jsc.templateLiteral(
+          [jsc.templateElement({raw: message, cooked: message}, true)], []));
+      (tombstone as NodeWithComments).comments = nodePathComments;
+      nodePath.insertBefore(tombstone);
+    }
     for (const {node} of namespaceExports) {
       nodePath.insertBefore(node);
     }
@@ -311,7 +322,8 @@ function getNamespaceExports(
     namespaceName: string) {
   const exportRecords: {name: string, node: estree.Node}[] = [];
 
-  for (const {key, value} of namespace.properties) {
+  for (const propNode of namespace.properties) {
+    const {key, value} = propNode;
     if (key.type !== 'Identifier') {
       console.warn(`unsupported namespace property type ${key.type}`);
       continue;
@@ -323,36 +335,32 @@ function getNamespaceExports(
     const isMutable = mutableNames.has(fullName) || mutableNames.has(thisName);
     if (value.type === 'ObjectExpression' || value.type === 'ArrayExpression' ||
         value.type === 'Literal') {
-      exportRecords.push({
-        name,
-        node: jsc.exportNamedDeclaration(jsc.variableDeclaration(
-            isMutable ? 'let' : 'const', [jsc.variableDeclarator(key, value)]))
-      });
+      const node = jsc.exportNamedDeclaration(jsc.variableDeclaration(
+          isMutable ? 'let' : 'const', [jsc.variableDeclarator(key, value)]));
+      (node as NodeWithComments).comments = getCommentsFromNode(propNode);
+      exportRecords.push({name, node});
     } else if (value.type === 'FunctionExpression') {
       const func = value;
-      exportRecords.push({
-        name,
-        node: jsc.exportNamedDeclaration(jsc.functionDeclaration(
-            key,  // id
-            func.params,
-            func.body,
-            func.generator))
-      });
+      const node = jsc.exportNamedDeclaration(jsc.functionDeclaration(
+          key,  // id
+          func.params,
+          func.body,
+          func.generator));
+      (node as NodeWithComments).comments = getCommentsFromNode(propNode);
+      exportRecords.push({name, node});
     } else if (value.type === 'ArrowFunctionExpression') {
       const isMutable =
           mutableNames.has(fullName) || mutableNames.has(thisName);
-      exportRecords.push({
-        name,
-        node: jsc.exportNamedDeclaration(jsc.variableDeclaration(
-            isMutable ? 'let' : 'const', [jsc.variableDeclarator(key, value)]))
-      });
+      const node = jsc.exportNamedDeclaration(jsc.variableDeclaration(
+          isMutable ? 'let' : 'const', [jsc.variableDeclarator(key, value)]));
+      (node as NodeWithComments).comments = getCommentsFromNode(propNode);
+      exportRecords.push({name, node});
     } else if (value.type === 'Identifier') {
-      exportRecords.push({
-        name,
-        node: jsc.exportNamedDeclaration(
-            null,
-            [jsc.exportSpecifier(jsc.identifier(name), jsc.identifier(name))]),
-      });
+      const node = jsc.exportNamedDeclaration(
+          null,
+          [jsc.exportSpecifier(jsc.identifier(name), jsc.identifier(name))]);
+      (node as NodeWithComments).comments = getCommentsFromNode(propNode);
+      exportRecords.push({name, node});
     } else {
       console.warn('Namespace property not handled:', name, value);
     }
@@ -445,11 +453,28 @@ function replacePreservingComments(
     nodePath: NodePath, replacement: estree.Node) {
   const comments = getComments(nodePath);
   nodePath.replace(replacement);
-  const commentsToRemove = new Set<estree.Comment>();
-  for (const comment of comments) {
-    if (!jsdocToRemove.test(comment.value)) {
-      continue;
-    }
+  (nodePath.node as any).comments = comments;
+}
+
+type NodeWithComments = estree.Node&{comments?: estree.Comment[]};
+
+
+function getComments(nodePath: NodePath) {
+  return getCommentsFromNode(nodePath.node);
+}
+function getCommentsFromNode(node: estree.Node&
+                             {comments?: estree.Comment[]}): estree.Comment[] {
+  const results = [];
+  if (node.comments) {
+    results.push(...node.comments);
+  }
+  return correctComments(results);
+}
+
+function correctComments(comments: estree.Comment[]): estree.Comment[] {
+  const correctedComments = [];
+  for (const existingComment of comments) {
+    const comment = {...existingComment};
     // Filter out namespace and memberof comments, which no longer make sense.
     const lines = comment.value.split('\n');
     comment.value =
@@ -467,21 +492,9 @@ function replacePreservingComments(
     // If a comment now only has whitespace and * charactes, we should filter it
     // out entirely.
     if (!/[^\s\*]/.test(comment.value)) {
-      commentsToRemove.add(comment);
+      continue;
     }
+    correctedComments.push(comment);
   }
-  (nodePath.node as any).comments =
-      comments.filter((c) => !commentsToRemove.has(c));
-}
-
-function getComments(nodePath: NodePath) {
-  return getCommentsFromNode(nodePath.node);
-}
-function getCommentsFromNode(node: estree.Node&
-                             {comments?: estree.Comment[]}): estree.Comment[] {
-  const results = [];
-  if (node.comments) {
-    results.push(...node.comments);
-  }
-  return results;
+  return correctedComments;
 }

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -3256,7 +3256,7 @@ export const MyMixinFunction = function() {};
  * @summary This is a summary on the namespace.
  */
 \`TODO(modulizer): A namespace named Polymer.Foo was
-declared here. The above comments should be reviewed,
+declared here. The surrounding comments should be reviewed,
 and this string can then be deleted\`;
 
 /**

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -942,6 +942,7 @@ export function fn() {
   foobar();
 }
 
+// NOTE: this is not a valid reference to Namespace.foobar
 export const isArrowFn = () => {
   this.foobar();
 };
@@ -3189,9 +3190,8 @@ console.log('second script');
             Polymer.MyBehavior = {};
 
             /**
-             * This comment is also important, but its
-             * whitespace is handled better, because it doesn't
-             * have any lines that need filtering out.
+             * This comment is also important!
+             *
              * @polymer
              * @mixinFunction
              */
@@ -3210,9 +3210,8 @@ console.log('second script');
 export const MyBehavior = {};
 
 /**
- * This comment is also important, but its
- * whitespace is handled better, because it doesn't
- * have any lines that need filtering out.
+ * This comment is also important!
+ *
  * @polymer
  * @mixinFunction
  */
@@ -3220,6 +3219,59 @@ export const MyMixinFunction = function() {};
 `,
       });
     });
+
+    testName = 'copy over namespace method comments';
+    test(testName, async () => {
+      setSources({
+        'test.html': `
+          <script>
+            /**
+             * This is a comment on the namespace itself.
+             *
+             * @namespace
+             * @memberof Polymer
+             * @summary This is a summary on the namespace.
+             */
+            Polymer.Foo = {
+              /**
+               * This is a method on Foo.
+               *
+               * @function
+               * @memberof Foo
+               * @return {string}
+               */
+              methodOnFoo() {
+                return 'foo result';
+              }
+            };
+          </script>
+        `
+      });
+
+      assertSources(await convert(), {
+        'test.js': `
+/**
+ * This is a comment on the namespace itself.
+ *
+ * @summary This is a summary on the namespace.
+ */
+\`TODO(modulizer): A namespace named Polymer.Foo was
+declared here. The above comments should be reviewed,
+and this string can then be deleted\`;
+
+/**
+ * This is a method on Foo.
+ *
+ * @function
+ * @return {string}
+ */
+export function methodOnFoo() {
+  return 'foo result';
+}
+`,
+      });
+    });
+
 
     suite('regression tests', () => {
       testName = `propagate templates for scripts consisting ` +


### PR DESCRIPTION
Fixes https://github.com/Polymer/polymer-modulizer/issues/398

Can confirm that this saves many hundreds of lines of comments from Polymer core.

Probably much less from other projects, as Polymer core uses a _lot_ of namespaces.