### PR TITLE
Preserve comments more reliably.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
     "modulizer_workspace/**": true,
     "untouched_workspace/**": true,
     "modularizer_workspace/**": true,
-    "fixtures/generated/**": true
+    "fixtures/packages/**": true
   },
   "html.format.enable": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `package.json`. Both default to `false`.
 * `deleteFiles` option will no longer delete any file from `node_modules/` or
   `bower_components/`.
+* Preserve comments more reliably.
 <!-- Add new, unreleased changes here. -->
 
 ## [0.3.0] - 2017-11-28

--- a/custom_typings/ast-types.d.ts
+++ b/custom_typings/ast-types.d.ts
@@ -1,8 +1,8 @@
 
 declare module 'ast-types' {
-  import * as estree from 'estree';
-  import {Node} from 'estree';
-  export interface NodePath<N extends Node = Node> {
+import * as estree from 'estree';
+import {Node} from 'estree';
+  export interface NodePath<N = Node> {
     node: N;
     parent?: NodePath;
 
@@ -46,10 +46,10 @@ declare module 'ast-types' {
         (this: VisitorContext, path: NodePath<estree.Program>): void|boolean;
     visitEmptyStatement?
         (this: VisitorContext, path: NodePath<estree.EmptyStatement>):
-      void | boolean;
+            void|boolean;
     visitCallExpression?
         (this: VisitorContext, path: NodePath<estree.CallExpression>):
-      void | boolean;
+            void|boolean;
     visitBlockStatement?
         (this: VisitorContext, path: NodePath<estree.BlockStatement>):
             void|boolean;

--- a/fixtures/packages/iron-icon/expected/iron-icon.js
+++ b/fixtures/packages/iron-icon/expected/iron-icon.js
@@ -83,6 +83,10 @@ Custom property | Description | Default
 @hero hero.svg
 @homepage polymer.github.io
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
 

--- a/fixtures/packages/paper-button/expected/paper-button.js
+++ b/fixtures/packages/paper-button/expected/paper-button.js
@@ -95,6 +95,7 @@ $_documentContainer.innerHTML = `<dom-module id="paper-button">
 </dom-module>`;
 
 document.head.appendChild($_documentContainer);
+
 /**
 @license
 Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
@@ -171,6 +172,10 @@ Custom property | Description | Default
 
 @demo demo/index.html
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
   is: 'paper-button',

--- a/fixtures/packages/polymer/expected/lib/elements/array-selector.js
+++ b/fixtures/packages/polymer/expected/lib/elements/array-selector.js
@@ -4,6 +4,19 @@ import { calculateSplices } from '../utils/array-splice.js';
 import { ElementMixin } from '../mixins/element-mixin.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Element mixin for recording dynamic associations between item paths in a
  * master `items` array and a `selected` array such that path changes to the
  * master array (at the host) element or elsewhere via data-binding) are

--- a/fixtures/packages/polymer/expected/lib/elements/custom-style.js
+++ b/fixtures/packages/polymer/expected/lib/elements/custom-style.js
@@ -1,6 +1,19 @@
 import '../../../../@webcomponents/shadycss/entrypoints/custom-style-interface.js';
 import { cssFromModules } from '../utils/style-gather.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 const attr = 'include';
 
 const CustomStyleInterface = window.ShadyCSS.CustomStyleInterface;

--- a/fixtures/packages/polymer/expected/lib/elements/dom-bind.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-bind.js
@@ -4,6 +4,19 @@ import { OptionalMutableData } from '../mixins/mutable-data.js';
 import { GestureEventListeners } from '../mixins/gesture-event-listeners.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * @constructor
  * @extends {HTMLElement}
  * @implements {Polymer_PropertyEffects}

--- a/fixtures/packages/polymer/expected/lib/elements/dom-if.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-if.js
@@ -6,6 +6,19 @@ import { microTask } from '../utils/async.js';
 import { root as root$0 } from '../utils/path.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * The `<dom-if>` element will stamp a light-dom `<template>` child when
  * the `if` property becomes truthy, and the template can use Polymer
  * data-binding and declarative event features when used in the context of

--- a/fixtures/packages/polymer/expected/lib/elements/dom-module.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-module.js
@@ -1,6 +1,19 @@
 import '../utils/boot.js';
 import { resolveUrl, pathFromUrl } from '../utils/resolve-url.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let modules = {};
 let lcModules = {};
 function findModule(id) {

--- a/fixtures/packages/polymer/expected/lib/elements/dom-repeat.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-repeat.js
@@ -6,6 +6,19 @@ import { OptionalMutableData } from '../mixins/mutable-data.js';
 import { matches, translate } from '../utils/path.js';
 import { timeOut, microTask } from '../utils/async.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let TemplateInstanceBase = TemplateInstanceBase$0; // eslint-disable-line
 
 /**

--- a/fixtures/packages/polymer/expected/lib/legacy/class.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/class.js
@@ -1,6 +1,19 @@
 import { LegacyElementMixin } from './legacy-element-mixin.js';
 import { DomModule } from '../elements/dom-module.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let metaProps = {
   attached: true,
   detached: true,

--- a/fixtures/packages/polymer/expected/lib/legacy/legacy-element-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/legacy-element-mixin.js
@@ -12,6 +12,19 @@ import { Debouncer } from '../utils/debounce.js';
 import { timeOut, microTask } from '../utils/async.js';
 import { get as get$0 } from '../utils/path.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let styleInterface = window.ShadyCSS;
 
 /**

--- a/fixtures/packages/polymer/expected/lib/legacy/mutable-data-behavior.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/mutable-data-behavior.js
@@ -1,5 +1,18 @@
 import { MutableData } from '../mixins/mutable-data.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let mutablePropertyChange;
 /** @suppress {missingProperties} */
 (() => {

--- a/fixtures/packages/polymer/expected/lib/legacy/polymer-fn.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/polymer-fn.js
@@ -1,6 +1,19 @@
 import { Class } from './class.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Legacy class factory and registration helper for defining Polymer
  * elements.
  *

--- a/fixtures/packages/polymer/expected/lib/legacy/polymer.dom.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/polymer.dom.js
@@ -3,6 +3,19 @@ import '../utils/settings.js';
 import { FlattenedNodesObserver } from '../utils/flattened-nodes-observer.js';
 import { flush as flush$0, enqueueDebouncer } from '../utils/flush.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 const p = Element.prototype;
 /**
  * @const {function(this:Node, string): boolean}

--- a/fixtures/packages/polymer/expected/lib/legacy/templatizer-behavior.js
+++ b/fixtures/packages/polymer/expected/lib/legacy/templatizer-behavior.js
@@ -1,5 +1,18 @@
 import { TemplateInstanceBase as TemplateInstanceBase$0, templatize as templatize$0, modelForElement as modelForElement$0 } from '../utils/templatize.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let TemplateInstanceBase = TemplateInstanceBase$0; // eslint-disable-line
 
 /**

--- a/fixtures/packages/polymer/expected/lib/mixins/dir-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/dir-mixin.js
@@ -1,6 +1,19 @@
 import { PropertyAccessors } from './property-accessors.js';
 import { dedupingMixin } from '../utils/mixin.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 const HOST_DIR = /:host\(:dir\((ltr|rtl)\)\)/g;
 const HOST_DIR_REPLACMENT = ':host([dir="$1"])';
 

--- a/fixtures/packages/polymer/expected/lib/mixins/disable-upgrade-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/disable-upgrade-mixin.js
@@ -1,6 +1,19 @@
 import { ElementMixin } from './element-mixin.js';
 import { dedupingMixin } from '../utils/mixin.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 const DISABLED_ATTR = 'disable-upgrade';
 
 /**

--- a/fixtures/packages/polymer/expected/lib/mixins/element-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/element-mixin.js
@@ -8,6 +8,19 @@ import { PropertyEffects } from './property-effects.js';
 import { PropertiesMixin } from './properties-mixin.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Element class mixin that provides the core API for Polymer's meta-programming
  * features including template stamping, data-binding, attribute deserialization,
  * and property change observation.

--- a/fixtures/packages/polymer/expected/lib/mixins/gesture-event-listeners.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/gesture-event-listeners.js
@@ -3,6 +3,19 @@ import { dedupingMixin } from '../utils/mixin.js';
 import * as gestures$0 from '../utils/gestures.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * @const {Polymer.Gestures}
  */
 const gestures = gestures$0;

--- a/fixtures/packages/polymer/expected/lib/mixins/mutable-data.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/mutable-data.js
@@ -1,5 +1,18 @@
 import { dedupingMixin } from '../utils/mixin.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 // Common implementation for mixin & behavior
 function mutablePropertyChange(inst, property, value, old, mutableData) {
   let isObject;

--- a/fixtures/packages/polymer/expected/lib/mixins/properties-changed.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/properties-changed.js
@@ -2,6 +2,19 @@ import '../utils/boot.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { microTask } from '../utils/async.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 /** @const {!AsyncInterface} */
 const microtask = microTask;
 

--- a/fixtures/packages/polymer/expected/lib/mixins/properties-mixin.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/properties-mixin.js
@@ -3,6 +3,19 @@ import { dedupingMixin } from '../utils/mixin.js';
 import { PropertiesChanged } from './properties-changed.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Creates a copy of `props` with each property normalized such that
  * upgraded it is an object with at least a type property { type: Type}.
  *

--- a/fixtures/packages/polymer/expected/lib/mixins/property-accessors.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/property-accessors.js
@@ -3,6 +3,19 @@ import { dedupingMixin } from '../utils/mixin.js';
 import * as caseMap$0 from '../utils/case-map.js';
 import { PropertiesChanged } from './properties-changed.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let caseMap = caseMap$0;
 
 // Save map of native properties; this forms a blacklist or properties

--- a/fixtures/packages/polymer/expected/lib/mixins/property-effects.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/property-effects.js
@@ -7,6 +7,21 @@ import { PropertyAccessors } from './property-accessors.js';
 import { TemplateStamp } from './template-stamp.js';
 import { sanitizeDOMValue } from '../utils/settings.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+/* for notify, reflect */
+/* for annotated effects */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 /** @const {Object} */
 const CaseMap = caseMap;
 

--- a/fixtures/packages/polymer/expected/lib/mixins/template-stamp.js
+++ b/fixtures/packages/polymer/expected/lib/mixins/template-stamp.js
@@ -1,6 +1,19 @@
 import '../utils/boot.js';
 import { dedupingMixin } from '../utils/mixin.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 // 1.x backwards-compatible auto-wrapper for template type extensions
 // This is a clear layering violation and gives favored-nation status to
 // dom-if and dom-repeat templates.  This is a conceit we're choosing to keep

--- a/fixtures/packages/polymer/expected/lib/utils/array-splice.js
+++ b/fixtures/packages/polymer/expected/lib/utils/array-splice.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 function newSplice(index, removed, addedCount) {
   return {
     index: index,

--- a/fixtures/packages/polymer/expected/lib/utils/async.js
+++ b/fixtures/packages/polymer/expected/lib/utils/async.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 // Microtask implemented using Mutation Observer
 let microtaskCurrHandle = 0;
 let microtaskLastHandle = 0;

--- a/fixtures/packages/polymer/expected/lib/utils/case-map.js
+++ b/fixtures/packages/polymer/expected/lib/utils/case-map.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 const caseMap = {};
 const DASH_TO_CAMEL = /-[a-z]/g;
 const CAMEL_TO_DASH = /([A-Z])/g;

--- a/fixtures/packages/polymer/expected/lib/utils/debounce.js
+++ b/fixtures/packages/polymer/expected/lib/utils/debounce.js
@@ -3,6 +3,19 @@ import './mixin.js';
 import './async.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * @summary Collapse multiple callbacks into one invocation after a timer.
  * @memberof Polymer
  */

--- a/fixtures/packages/polymer/expected/lib/utils/flattened-nodes-observer.js
+++ b/fixtures/packages/polymer/expected/lib/utils/flattened-nodes-observer.js
@@ -3,6 +3,19 @@ import { calculateSplices } from './array-splice.js';
 import { microTask } from './async.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Returns true if `node` is a slot element
  * @param {Node} node Node to test.
  * @return {boolean} Returns true if the given `node` is a slot

--- a/fixtures/packages/polymer/expected/lib/utils/flush.js
+++ b/fixtures/packages/polymer/expected/lib/utils/flush.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let debouncerQueue = [];
 
 /**

--- a/fixtures/packages/polymer/expected/lib/utils/gestures.js
+++ b/fixtures/packages/polymer/expected/lib/utils/gestures.js
@@ -3,6 +3,19 @@ import { timeOut, microTask } from './async.js';
 import { Debouncer } from './debounce.js';
 import { passiveTouchGestures } from './settings.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 // detect native touch action support
 let HAS_NATIVE_TA = typeof document.head.style.touchAction === 'string';
 let GESTURE_KEY = '__polymerGestures';

--- a/fixtures/packages/polymer/expected/lib/utils/html-tag.js
+++ b/fixtures/packages/polymer/expected/lib/utils/html-tag.js
@@ -1,6 +1,19 @@
 import './boot.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Class representing a static string value which can be used to filter
  * strings by asseting that they have been created via this class. The
  * `value` property returns the string passed to the constructor.

--- a/fixtures/packages/polymer/expected/lib/utils/import-href.js
+++ b/fixtures/packages/polymer/expected/lib/utils/import-href.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 // run a callback when HTMLImports are ready or immediately if
 // this api is not available.
 function whenImportsReady(cb) {

--- a/fixtures/packages/polymer/expected/lib/utils/mixin.js
+++ b/fixtures/packages/polymer/expected/lib/utils/mixin.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 // unique global id for deduping mixins.
 let dedupeId = 0;
 

--- a/fixtures/packages/polymer/expected/lib/utils/path.js
+++ b/fixtures/packages/polymer/expected/lib/utils/path.js
@@ -1,6 +1,19 @@
 import './boot.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Module with utilities for manipulating structured data path strings.
  *
  * @summary Module with utilities for manipulating structured data path strings.

--- a/fixtures/packages/polymer/expected/lib/utils/render-status.js
+++ b/fixtures/packages/polymer/expected/lib/utils/render-status.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let scheduled = false;
 let beforeRenderQueue = [];
 let afterRenderQueue = [];

--- a/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
+++ b/fixtures/packages/polymer/expected/lib/utils/resolve-url.js
@@ -1,5 +1,18 @@
 import './boot.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let CSS_URL_RX = /(url\()([^)]*)(\))/g;
 let ABS_URL = /(^\/)|(^#)|(^[\w-\d]*:)/;
 let workingURL;

--- a/fixtures/packages/polymer/expected/lib/utils/settings.js
+++ b/fixtures/packages/polymer/expected/lib/utils/settings.js
@@ -1,5 +1,19 @@
 import './boot.js';
 import { pathFromUrl } from './resolve-url.js';
+
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 export const useShadow = !(window.ShadyDOM);
 export const useNativeCSSProperties = Boolean(!window.ShadyCSS || window.ShadyCSS.nativeCss);
 export const useNativeCustomElements = !(window.customElements.polyfillWrapFlushCallback);

--- a/fixtures/packages/polymer/expected/lib/utils/style-gather.js
+++ b/fixtures/packages/polymer/expected/lib/utils/style-gather.js
@@ -1,5 +1,18 @@
 import { resolveCss } from './resolve-url.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 const MODULE_STYLE_LINK_SELECTOR = 'link[rel=import][type~=css]';
 const INCLUDE_ATTR = 'include';
 const SHADY_UNSCOPED_ATTR = 'shady-unscoped';

--- a/fixtures/packages/polymer/expected/lib/utils/templatize.js
+++ b/fixtures/packages/polymer/expected/lib/utils/templatize.js
@@ -2,6 +2,19 @@ import './boot.js';
 import { PropertyEffects } from '../mixins/property-effects.js';
 import { MutableData } from '../mixins/mutable-data.js';
 
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 // Base class for HTMLTemplateElement extension that has property effects
 // machinery for propagating host properties to children. This is an ES5
 // class only because Babel (incorrectly) requires super() in the class

--- a/fixtures/packages/polymer/expected/polymer-element.js
+++ b/fixtures/packages/polymer/expected/polymer-element.js
@@ -2,6 +2,20 @@ import { ElementMixin } from './lib/mixins/element-mixin.js';
 import { html as html$0 } from './lib/utils/html-tag.js';
 
 /**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+/* import html-tag to export html */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+/**
  * Base class that provides the core API for Polymer's meta-programming
  * features including template stamping, data-binding, attribute deserialization,
  * and property change observation.

--- a/fixtures/packages/polymer/expected/polymer-legacy.js
+++ b/fixtures/packages/polymer/expected/polymer-legacy.js
@@ -9,7 +9,6 @@ import './lib/elements/custom-style.js';
 import './lib/legacy/mutable-data-behavior.js';
 import { html as html$0 } from './lib/utils/html-tag.js';
 
-// bc
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -23,6 +22,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 /* custom-style */
 /* bc behaviors */
 /* import html-tag to export html */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
+// bc
 export const Base = LegacyElementMixin(HTMLElement).prototype;
 
 // NOTE: this is here for modulizer to export `html` for the module version of this file

--- a/fixtures/packages/polymer/expected/test/unit/array-selector-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/array-selector-elements.js
@@ -1,4 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -8,6 +9,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
   is: 'observe-el',

--- a/fixtures/packages/polymer/expected/test/unit/attributes-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/attributes-elements.js
@@ -1,5 +1,6 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -9,6 +10,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let PropertyTypeBehavior = {
   properties: {
     behaviorShorthandNumber: Number,

--- a/fixtures/packages/polymer/expected/test/unit/custom-style-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style-import.js
@@ -43,4 +43,6 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-;
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;

--- a/fixtures/packages/polymer/expected/test/unit/dom-bind-elements1.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-bind-elements1.js
@@ -1,5 +1,6 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -9,6 +10,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
   is: 'x-basic',

--- a/fixtures/packages/polymer/expected/test/unit/dom-bind-elements2.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-bind-elements2.js
@@ -1,4 +1,5 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -8,6 +9,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
   is: 'x-needs-host',

--- a/fixtures/packages/polymer/expected/test/unit/dom-if-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-if-elements.js
@@ -1,5 +1,6 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -9,6 +10,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
 

--- a/fixtures/packages/polymer/expected/test/unit/dom-repeat-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-repeat-elements.js
@@ -1,6 +1,7 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
 import { MutableData } from '../../lib/mixins/mutable-data.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -10,6 +11,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 window.getData = () => [
   {
     prop: 'prop-1',

--- a/fixtures/packages/polymer/expected/test/unit/dynamic-imports/dynamic-element.js
+++ b/fixtures/packages/polymer/expected/test/unit/dynamic-imports/dynamic-element.js
@@ -2,6 +2,7 @@ import '../../../polymer-legacy.js';
 import { Polymer } from '../../../lib/legacy/polymer-fn.js';
 import { html } from '../../../lib/utils/html-tag.js';
 import { dom } from '../../../lib/legacy/polymer.dom.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -11,6 +12,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
 

--- a/fixtures/packages/polymer/expected/test/unit/dynamic-imports/inner-element.js
+++ b/fixtures/packages/polymer/expected/test/unit/dynamic-imports/inner-element.js
@@ -1,6 +1,7 @@
 import '../../../polymer-legacy.js';
 import { Polymer } from '../../../lib/legacy/polymer-fn.js';
 import { html } from '../../../lib/utils/html-tag.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -10,6 +11,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
 

--- a/fixtures/packages/polymer/expected/test/unit/events-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/events-elements.js
@@ -1,6 +1,7 @@
 import { Base } from '../../polymer-legacy.js';
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -10,6 +11,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 var EventLoggerImpl = {
   created: function() {
     this._handled = {};

--- a/fixtures/packages/polymer/expected/test/unit/gestures-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/gestures-elements.js
@@ -3,6 +3,7 @@ import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
 import { PolymerElement } from '../../polymer-element.js';
 import { GestureEventListeners } from '../../lib/mixins/gesture-event-listeners.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -12,6 +13,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
 

--- a/fixtures/packages/polymer/expected/test/unit/path-effects-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/path-effects-elements.js
@@ -1,6 +1,7 @@
 import { PropertiesMixin } from '../../lib/mixins/properties-mixin.js';
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -10,6 +11,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 class XPropertiesElement extends PropertiesMixin(HTMLElement) {
   static get importPath() {
     return import.meta.url;

--- a/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply-import.js
@@ -2,6 +2,7 @@ import { PolymerElement } from '../../polymer-element.js';
 import '../../../../@webcomponents/shadycss/entrypoints/apply-shim.js';
 import '../../lib/elements/custom-style.js';
 import { html } from '../../lib/utils/html-tag.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -11,6 +12,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 class ApplyElement extends PolymerElement {
   static get importPath() {
     return import.meta.url;

--- a/fixtures/packages/polymer/expected/test/unit/property-effects-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/property-effects-elements.js
@@ -4,6 +4,7 @@ import { html } from '../../lib/utils/html-tag.js';
 import { PolymerElement } from '../../polymer-element.js';
 import { MutableDataBehavior } from '../../lib/legacy/mutable-data-behavior.js';
 import { MutableData } from '../../lib/mixins/mutable-data.js';
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -13,6 +14,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 let ComputingBehavior = {
   properties: {
     computeFromBehavior: Function

--- a/fixtures/packages/polymer/expected/test/unit/shady-unscoped-style-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/shady-unscoped-style-import.js
@@ -36,4 +36,6 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-;
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;

--- a/fixtures/packages/polymer/expected/test/unit/styling-import-shared-styles.js
+++ b/fixtures/packages/polymer/expected/test/unit/styling-import-shared-styles.js
@@ -29,4 +29,6 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-;
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;

--- a/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
@@ -4,6 +4,7 @@ const $_documentContainer = document.createElement('div');
 $_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = `<dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>`;
 document.head.appendChild($_documentContainer);
+
 /**
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -13,6 +14,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 class PR extends PolymerElement {
   static get importPath() {
     return import.meta.url;

--- a/fixtures/packages/polymer/expected/test/unit/templatize-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/templatize-elements.js
@@ -12,6 +12,10 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!`;
+
 Polymer({
   importPath: import.meta.url,
   is: 'x-child',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3764,9 +3764,9 @@
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "mocha": "^3.5.3",
     "tsc-then": "^1.1.0",
     "tslint": "^5.5.0",
-    "typescript": "^2.6.2"
+    "typescript": "^2.8.1"
   }
 }

--- a/src/document-util.ts
+++ b/src/document-util.ts
@@ -412,8 +412,8 @@ export function attachCommentsToFirstStatement(
       `  from HTML and may be out of place here. Review them and\n` +
       `  then delete this string!`;
   const firstStatement = jsc.expressionStatement(jsc.templateLiteral(
-      [jsc.templateElement({cooked: message, raw: message}, true)], []));
-  statements.unshift(firstStatement) as RecastNode;
+      [jsc.templateElement({cooked: message, raw: message}, true)], [])) as RecastNode & estree.ExpressionStatement;
+  statements.unshift(firstStatement);
 
   /** Recast represents comments differently than espree. */
   interface RecastNode {

--- a/src/document-util.ts
+++ b/src/document-util.ts
@@ -408,10 +408,12 @@ export function attachCommentsToFirstStatement(
   if (comments.length === 0) {
     return statements;
   }
-  if (statements.length === 0) {
-    // Create the emptiest statement we can. This is serialized as just ';'
-    statements = [jsc.expressionStatement(jsc.identifier(''))];
-  }
+  const message = `TODO(modulizer): the above comments were extracted\n` +
+      `  from HTML and may be out of place here. Review them and\n` +
+      `  then delete this string!`;
+  const firstStatement = jsc.expressionStatement(jsc.templateLiteral(
+      [jsc.templateElement({cooked: message, raw: message}, true)], []));
+  statements.unshift(firstStatement) as RecastNode;
 
   /** Recast represents comments differently than espree. */
   interface RecastNode {
@@ -424,9 +426,6 @@ export function attachCommentsToFirstStatement(
     trailing: boolean;
     value: string;
   }
-  const firstStatement: (estree.Statement|estree.ModuleDeclaration)&RecastNode =
-      statements[0]!;
-
   const recastComments: RecastComment[] = comments.map((comment) => {
     const escapedComment = comment.replace(/\*\//g, '*\\/');
     return {
@@ -436,6 +435,7 @@ export function attachCommentsToFirstStatement(
       value: escapedComment,
     };
   });
+
   firstStatement.comments =
       (firstStatement.comments || []).concat(recastComments);
 

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -3093,7 +3093,9 @@ console.log('two');
 /* Second comment */
 /* Another comment */
 /* Final trailing comment */
-;
+\`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!\`;
 
 // comment in script
 console.log('second script');
@@ -3116,7 +3118,9 @@ console.log('second script');
 /* First comment */
 /* Second comment */
 /* Final trailing comment */
-;
+\`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!\`;
 `,
       });
     });
@@ -3142,7 +3146,6 @@ console.log('second script');
 
       assertSources(await convert(), {
         'test.js': `
-// comment in script
 /* /* First comment *\\/ */
 /* /* 1/2 comments *\\/ /* 2/2 comments *\\/ */
 /*
@@ -3150,6 +3153,11 @@ console.log('second script');
    *  Final comment
    **\\/
 */
+\`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!\`;
+
+// comment in script
 console.log('second script');
 `,
       });
@@ -3171,7 +3179,9 @@ console.log('second script');
 /** @license This is a license */
 /* Second comment */
 /* Final trailing comment */
-;
+\`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!\`;
 `,
       });
     });
@@ -3272,6 +3282,76 @@ export function methodOnFoo() {
       });
     });
 
+    testName = 'copy header comments';
+    test(testName, async () => {
+
+      setSources({
+        'test.html': `<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<script>
+(function() {
+  'use strict';
+
+  // unresolved
+
+  function resolve() {
+    document.body.removeAttribute('unresolved');
+  }
+
+  if (window.WebComponents) {
+    window.addEventListener('WebComponentsReady', resolve);
+  } else {
+    if (document.readyState === 'interactive' || document.readyState === 'complete') {
+      resolve();
+    } else {
+      window.addEventListener('DOMContentLoaded', resolve);
+    }
+  }
+
+})();
+</script>`
+      });
+
+      assertSources(await convert(), {
+        'test.js': `
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+\`TODO(modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this string!\`;
+
+// unresolved
+
+function resolve() {
+  document.body.removeAttribute('unresolved');
+}
+
+if (window.WebComponents) {
+  window.addEventListener('WebComponentsReady', resolve);
+} else {
+  if (document.readyState === 'interactive' || document.readyState === 'complete') {
+    resolve();
+  } else {
+    window.addEventListener('DOMContentLoaded', resolve);
+  }
+}
+`,
+      });
+    });
 
     suite('regression tests', () => {
       testName = `propagate templates for scripts consisting ` +

--- a/src/tools/gen-ts-types.ts
+++ b/src/tools/gen-ts-types.ts
@@ -58,14 +58,15 @@ require('./def/esprima')(fork);
 
 const types = [...Type.types.values()];
 const builders = types.filter((t) => t._build != null).map((t) => {
+  const build = t._build!;
   const name = leadingLowerCase(t._name);
-  const fields = t._build.map((f) => getField(t, f)!);
+  const fields = build.map((f) => getField(t, f)!);
 
   let lastRequiredIndex = -1;
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i];
     if (field === undefined) {
-      console.error(`field not found: ${t._build[i]} for type ${t._name}`);
+      console.error(`field not found: ${build[i]} for type ${t._name}`);
     }
     const optional = field.default != null || nullable(field.type);
     if (!optional) {
@@ -74,7 +75,7 @@ const builders = types.filter((t) => t._build != null).map((t) => {
   }
 
   let i = 0;
-  const args = t._build.map((f) => {
+  const args = build.map((f) => {
     const field = getField(t, f);
     if (field == null) {
       console.error(`field ${f} not found for type ${t._name}`);

--- a/src/tools/lib/types.ts
+++ b/src/tools/lib/types.ts
@@ -14,9 +14,9 @@
 
 export class Def {
   _name: string;
-  _bases: string[];
+  _bases: string[]|undefined;
   _fields = new Map<string, Field>();
-  _build: string[];
+  _build: string[]|undefined;
 
   constructor(name: string) {
     this._name = name;


### PR DESCRIPTION
Sometimes we were moving comments out of HTML and onto the first JS node. This is fine, except that we were then pruning that first JS node!

We should probably move to always preserving comments when pruning/replacing nodes, but this also gives us a place to let people know where these comments came from, and that they need review.