### PR TITLE
Import path to meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Setting the import style allows you to set whether JavaScript imports are specif
 
 #### `--add-import-meta
 
-True by default, but if set to false, the static `importMeta` property will not be added to converted Polymer elements. See [the `importPath` documentation](https://www.polymer-project.org/2.0/docs/devguide/dom-template) for more information.
+True by default; the static `importMeta` property will be added to converted Polymer elements. See [the `importPath` documentation](https://www.polymer-project.org/2.0/docs/devguide/dom-template) for more information.
 
 
 ## Conversion Guidelines

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ This will create a `modulizer_workspace` directory and checkout the repos and th
 
 Setting the import style allows you to set whether JavaScript imports are specified by npm package name, or relative file path. Importing specifiers that use package names are easier for third-party packages to work with, but unlike paths they currently can not run natively on the web. Defaults to "path".
 
-#### `--add-import-path`
+#### `--remove-import-meta
 
-If included, the static `importPath` property will be added to converted Polymer elements. See [the `importPath` documentation](https://www.polymer-project.org/2.0/docs/devguide/dom-template) for more information.
+If included, the static `importMeta` property will not be added to converted Polymer elements. See [the `importPath` documentation](https://www.polymer-project.org/2.0/docs/devguide/dom-template) for more information.
 
 
 ## Conversion Guidelines

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ This will create a `modulizer_workspace` directory and checkout the repos and th
 
 Setting the import style allows you to set whether JavaScript imports are specified by npm package name, or relative file path. Importing specifiers that use package names are easier for third-party packages to work with, but unlike paths they currently can not run natively on the web. Defaults to "path".
 
-#### `--remove-import-meta
+#### `--add-import-meta
 
-If included, the static `importMeta` property will not be added to converted Polymer elements. See [the `importPath` documentation](https://www.polymer-project.org/2.0/docs/devguide/dom-template) for more information.
+True by default, but if set to false, the static `importMeta` property will not be added to converted Polymer elements. See [the `importPath` documentation](https://www.polymer-project.org/2.0/docs/devguide/dom-template) for more information.
 
 
 ## Conversion Guidelines

--- a/fixtures/packages/iron-icon/expected/iron-icon.js
+++ b/fixtures/packages/iron-icon/expected/iron-icon.js
@@ -90,7 +90,7 @@ import { html } from '../../@polymer/polymer/lib/utils/html-tag.js';
 import { dom } from '../../@polymer/polymer/lib/legacy/polymer.dom.js';
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style>

--- a/fixtures/packages/paper-button/expected/paper-button.js
+++ b/fixtures/packages/paper-button/expected/paper-button.js
@@ -178,7 +178,7 @@ $_documentContainer.innerHTML = `<dom-module id="paper-button">
 
 document.head.appendChild($_documentContainer.content);
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'paper-button',
 
   behaviors: [

--- a/fixtures/packages/polymer/expected/lib/elements/array-selector.js
+++ b/fixtures/packages/polymer/expected/lib/elements/array-selector.js
@@ -425,8 +425,8 @@ let baseArraySelector = ArraySelectorMixin(PolymerElement);
  *   an output `selected` item or array based on calls to its selection API.
  */
 class ArraySelector extends baseArraySelector {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   // Not needed to find template; can be removed once the analyzer

--- a/fixtures/packages/polymer/expected/lib/elements/custom-style.js
+++ b/fixtures/packages/polymer/expected/lib/elements/custom-style.js
@@ -63,8 +63,8 @@ const CustomStyleInterface = window.ShadyCSS.CustomStyleInterface;
  *   take advantage of Polymer's style scoping and custom properties shims.
  */
 class CustomStyle extends HTMLElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   constructor() {

--- a/fixtures/packages/polymer/expected/lib/elements/dom-bind.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-bind.js
@@ -46,8 +46,8 @@ const domBindBase =
  *   binding, declarative event listeners, etc.) in the main document.
  */
 class DomBind extends domBindBase {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get observedAttributes() { return ['mutable-data']; }

--- a/fixtures/packages/polymer/expected/lib/elements/dom-if.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-if.js
@@ -38,8 +38,8 @@ import { root as root$0 } from '../utils/path.js';
  *   template content based on a boolean flag.
  */
 class DomIf extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   // Not needed to find template; can be removed once the analyzer

--- a/fixtures/packages/polymer/expected/lib/elements/dom-module.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-module.js
@@ -50,8 +50,8 @@ function styleOutsideTemplateCheck(inst) {
  * @unrestricted
  */
 class DomModule extends HTMLElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get observedAttributes() { return ['id']; }

--- a/fixtures/packages/polymer/expected/lib/elements/dom-repeat.js
+++ b/fixtures/packages/polymer/expected/lib/elements/dom-repeat.js
@@ -130,8 +130,8 @@ const domRepeatBase = OptionalMutableData(PolymerElement);
  *   items in an array.
  */
 class DomRepeat extends domRepeatBase {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   // Not needed to find template; can be removed once the analyzer

--- a/fixtures/packages/polymer/expected/lib/utils/templatize.js
+++ b/fixtures/packages/polymer/expected/lib/utils/templatize.js
@@ -63,8 +63,8 @@ const base = PropertyEffects(class {});
  * @unrestricted
  */
 class TemplateInstanceBase extends base {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   constructor(props) {

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements.js
@@ -2,7 +2,7 @@ import './elements-defaults.js';
 import { Polymer } from '../../../../lib/legacy/polymer-fn.js';
 import { html } from '../../../../lib/utils/html-tag.js';
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style include="simple-layout-styles">
@@ -59,7 +59,7 @@ Polymer({
   is: 'x-s'
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style include="simple-layout-styles">

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/scopes.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/scopes.js
@@ -5,7 +5,7 @@ import { html } from '../../../../lib/utils/html-tag.js';
 import { dom } from '../../../../lib/legacy/polymer.dom.js';
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style>
@@ -46,7 +46,7 @@ Polymer({
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style include="simple-layout-styles">
@@ -90,7 +90,7 @@ Polymer({
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style include="simple-layout-styles">

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
@@ -32,7 +32,7 @@ $_documentContainer.innerHTML = `<dom-module id="simple-layout-styles">
 
 document.head.appendChild($_documentContainer.content);
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style include="simple-layout-styles">

--- a/fixtures/packages/polymer/expected/test/unit/array-selector-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/array-selector-elements.js
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'observe-el',
 
   observers: [

--- a/fixtures/packages/polymer/expected/test/unit/attributes-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/attributes-elements.js
@@ -26,7 +26,7 @@ let PropertyTypeBehavior = {
 };
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-basic',
 
   hostAttributes: {
@@ -114,7 +114,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-reflect',
   behaviors: [ PropertyTypeBehavior ],
 
@@ -189,7 +189,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-basic id="basic" prop="{{attr1}}" attr1\$="{{attr1}}" class="should-not-override"></x-basic>

--- a/fixtures/packages/polymer/expected/test/unit/dom-bind-elements1.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-bind-elements1.js
@@ -11,7 +11,7 @@ import { Polymer } from '../../lib/legacy/polymer-fn.js';
 
 import { html } from '../../lib/utils/html-tag.js';
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-basic',
 
   properties: {
@@ -21,7 +21,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
 <div id="container"><slot id="slot"></slot></div>
@@ -30,7 +30,7 @@ Polymer({
   is: 'x-content'
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
 <x-content id="local"></x-content>
@@ -54,7 +54,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
 <x-content id="local"></x-content>
@@ -63,7 +63,7 @@ Polymer({
   is: 'x-compose'
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-produce-a',
 
   properties: {

--- a/fixtures/packages/polymer/expected/test/unit/dom-bind-elements2.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-bind-elements2.js
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-needs-host',
 
   attached: function() {

--- a/fixtures/packages/polymer/expected/test/unit/dom-if-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-if-elements.js
@@ -11,7 +11,7 @@ import { Polymer } from '../../lib/legacy/polymer-fn.js';
 
 import { html } from '../../lib/utils/html-tag.js';
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-bar id="bar" prop="{{prop}}" item-prop="{{item.prop}}">
@@ -30,7 +30,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-bar',
 
   properties: {
@@ -43,7 +43,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" id="if-1" if="{{shouldStamp}}" on-dom-change="domUpdateHandler">
@@ -90,7 +90,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" id="if-1" if="{{shouldStamp}}">
@@ -129,7 +129,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" id="if-1" if="{{shouldStamp1}}">
@@ -165,7 +165,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template id="domIf" is="dom-if" if="">
@@ -186,7 +186,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
       <template id="domIf" is="dom-if" if="">
@@ -207,7 +207,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template id="domif" is="dom-if" if="">
@@ -220,7 +220,7 @@ Polymer({
   is: 'x-host'
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-client',
 
   statics: {
@@ -232,7 +232,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="{{bool}}" restamp="{{restamp}}">{{guarded(bool)}}</template>
@@ -247,7 +247,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="{{isTrue(bool)}}" restamp="{{restamp}}">{{guarded(bool)}}</template>
@@ -266,7 +266,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="{{switch}}" restamp="{{restamp}}">{{guarded(bool)}}</template>
@@ -291,7 +291,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="{{obj.bool}}" restamp="{{restamp}}">{{guarded(obj.bool)}}</template>
@@ -306,7 +306,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="{{switch}}" restamp="{{restamp}}">{{guarded(obj.bool)}}</template>
@@ -331,7 +331,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="{{b}}" restamp="{{restamp}}">{{guarded(a)}}</template>
@@ -346,7 +346,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="{{obj.b}}" restamp="{{restamp}}">{{guarded(obj.a)}}</template>

--- a/fixtures/packages/polymer/expected/test/unit/dom-repeat-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/dom-repeat-elements.js
@@ -102,7 +102,7 @@ window.getData = () => [
 ];
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style>
@@ -159,7 +159,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-bar',
 
   properties: {
@@ -199,7 +199,7 @@ Polymer({
   }
 });
 let XNestedRepeat = Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: `
 <template id="repeater" is="dom-repeat" items="{{items}}" as="itema" index-as="indexa" on-dom-change="domUpdateHandler">
@@ -263,8 +263,8 @@ let XNestedRepeat = Polymer({
   }
 });
 class XNestedRepeatMutable extends MutableData(XNestedRepeat) {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {
@@ -284,7 +284,7 @@ class XNestedRepeatMutable extends MutableData(XNestedRepeat) {
 }
 customElements.define('x-nested-repeat-mutable', XNestedRepeatMutable);
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template id="repeater" is="dom-repeat" items="{{items}}" as="itema" index-as="indexa" observe="prop">
@@ -342,7 +342,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
       <template id="repeater" is="dom-repeat" items="{{items}}">
@@ -367,7 +367,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template id="repeat" is="dom-repeat" items="{{items}}">
@@ -384,7 +384,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="container1">
@@ -410,7 +410,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template id="repeater" is="dom-repeat" items="{{items}}">
@@ -433,7 +433,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template id="repeater" is="dom-repeat" items="{{items}}">
@@ -461,7 +461,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template id="repeater" is="dom-repeat" items="{{items}}" initial-count="10">
@@ -484,7 +484,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-wait',
 
   created: function() {
@@ -494,7 +494,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-repeat" items="{{items}}" id="outer">

--- a/fixtures/packages/polymer/expected/test/unit/dynamic-imports/dynamic-element.js
+++ b/fixtures/packages/polymer/expected/test/unit/dynamic-imports/dynamic-element.js
@@ -13,7 +13,7 @@ import { Polymer } from '../../../lib/legacy/polymer-fn.js';
 import { html } from '../../../lib/utils/html-tag.js';
 import { dom } from '../../../lib/legacy/polymer.dom.js';
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <span id="content">dynamic-element</span> :

--- a/fixtures/packages/polymer/expected/test/unit/dynamic-imports/inner-element.js
+++ b/fixtures/packages/polymer/expected/test/unit/dynamic-imports/inner-element.js
@@ -12,7 +12,7 @@ import '../../../polymer-legacy.js';
 import { Polymer } from '../../../lib/legacy/polymer-fn.js';
 import { html } from '../../../lib/utils/html-tag.js';
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <span id="content">inner-element</span>

--- a/fixtures/packages/polymer/expected/test/unit/events-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/events-elements.js
@@ -27,7 +27,7 @@ var EventLoggerImpl = {
   }
 };
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-listeners',
   behaviors: [EventLoggerImpl],
 
@@ -37,7 +37,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="inner" on-foo="handle" on-bar="missing"></div>
@@ -47,7 +47,7 @@ Polymer({
   behaviors: [EventLoggerImpl]
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
       <x-listeners id="inner" on-foo="handle"></x-listeners>
@@ -57,7 +57,7 @@ Polymer({
   behaviors: [EventLoggerImpl]
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="inner"></div>
@@ -81,7 +81,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-double',
   behaviors: [EventLoggerImpl],
 

--- a/fixtures/packages/polymer/expected/test/unit/gestures-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/gestures-elements.js
@@ -14,7 +14,7 @@ import { html } from '../../lib/utils/html-tag.js';
 import { PolymerElement } from '../../polymer-element.js';
 import { GestureEventListeners } from '../../lib/mixins/gesture-event-listeners.js';
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
   <style>
@@ -39,7 +39,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-foo id="foo"></x-foo>
@@ -57,7 +57,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="inner" on-tap="handler" on-track="handler" on-down="handler" on-up="handler"></div>
@@ -76,7 +76,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-dynamic',
   handler: function(){},
 
@@ -102,7 +102,7 @@ var EventCaptureBehavior = {
   }
 };
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   listeners: {
     'down': 'prevent',
@@ -122,7 +122,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-buttons',
 
   listeners: {
@@ -135,7 +135,7 @@ Polymer({
   behaviors: [EventCaptureBehavior]
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-document-listener',
 
   setup: function() {
@@ -149,7 +149,7 @@ Polymer({
   behaviors: [EventCaptureBehavior]
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-nested-child-prevent',
 
   listeners: {
@@ -159,7 +159,7 @@ Polymer({
   behaviors: [EventCaptureBehavior]
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <style>
@@ -192,13 +192,13 @@ Polymer({
   behaviors: [EventCaptureBehavior]
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-imperative',
   behaviors: [EventCaptureBehavior]
 });
 class XNativeLabel extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {
@@ -214,8 +214,8 @@ class XNativeLabel extends PolymerElement {
 }
 customElements.define(XNativeLabel.is, XNativeLabel);
 class XNativeLabelNested extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {
@@ -232,8 +232,8 @@ class XNativeLabelNested extends PolymerElement {
 }
 customElements.define(XNativeLabelNested.is, XNativeLabelNested);
 class XDisabled extends GestureEventListeners(PolymerElement) {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {

--- a/fixtures/packages/polymer/expected/test/unit/path-effects-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/path-effects-elements.js
@@ -12,8 +12,8 @@ import { PropertiesMixin } from '../../lib/mixins/properties-mixin.js';
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 import { html } from '../../lib/utils/html-tag.js';
 class XPropertiesElement extends PropertiesMixin(HTMLElement) {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get properties() {
@@ -36,7 +36,7 @@ class XPropertiesElement extends PropertiesMixin(HTMLElement) {
 }
 customElements.define('x-pe', XPropertiesElement);
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-basic',
 
   properties: {
@@ -54,7 +54,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-basic id="basic1" notifying-value="{{obj.value}}" attrvalue\$="{{obj.value}}" othervalue="{{obj.value2}}"></x-basic>
@@ -92,7 +92,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-compose id="compose" obj="{{obj}}"></x-compose>
@@ -132,7 +132,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-basic id="basic" notifying-value="{{nested.obj.value}}" attrvalue\$="{{nested.obj.value}}"></x-basic>
@@ -218,7 +218,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-reentry-client',
 
   properties: {
@@ -240,7 +240,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-reentry-client obj="{{obj}}" prop="{{prop}}"></x-reentry-client>
@@ -266,13 +266,13 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-path-client',
   observers: ['objChanged(obj.*)'],
   objChanged: function() {}
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-path-client id="client" obj="{{obj}}"></x-path-client>

--- a/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/polymer-element-with-apply-import.js
@@ -13,8 +13,8 @@ import '../../../../@webcomponents/shadycss/entrypoints/apply-shim.js';
 import '../../lib/elements/custom-style.js';
 import { html } from '../../lib/utils/html-tag.js';
 class ApplyElement extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {
@@ -32,8 +32,8 @@ class ApplyElement extends PolymerElement {
 }
 customElements.define('apply-element', ApplyElement);
 class XOuter extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {

--- a/fixtures/packages/polymer/expected/test/unit/property-effects-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/property-effects-elements.js
@@ -23,7 +23,7 @@ let ComputingBehavior = {
   }
 };
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="boundChild" value="{{ value }}" negvalue="{{!bool}}" attrvalue\$="{{attrvalue}}" sanitize-value="{{sanitizeValue}}" computedvalue="{{computedvalue}}" computedvaluetwo="{{computedvaluetwo}}" camel-case="{{value}}" computed-inline="{{computeInline(value,add, divide)}}" computed-inline2="{{computeInline(value, add,divide)}}" computed-inline3="{{computeInline(value, add,
@@ -321,7 +321,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-basic id="basic1" value="{{boundvalue}}" notifyingvalue="{{boundnotifyingvalue}}" notifyingvalue-with-default="{{boundnotifyingvalueWithDefault}}" camel-notifying-value="{{boundnotifyingvalue}}" computedvalue="{{boundcomputedvalue}}" computednotifyingvalue="{{boundcomputednotifyingvalue}}" readonlyvalue="{{boundreadonlyvalue}}" custom-notifying-value="{{boundCustomNotifyingValue}}">
@@ -426,7 +426,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <slot name="drawer"></slot>
@@ -459,7 +459,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-reflect',
 
   properties: {
@@ -490,7 +490,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-prop',
 
   properties: {
@@ -510,7 +510,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-notifies1',
 
   properties: {
@@ -524,7 +524,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-notifies1 id="notifies1" notifies="{{shouldChange}}"></x-notifies1>
@@ -539,7 +539,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-notifies2 id="notifies2" notifies="{{shouldNotChange}}"></x-notifies2>
@@ -556,7 +556,7 @@ Polymer({
   shouldNotChangeChanged: function() { }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <p>©</p>
@@ -573,7 +573,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <input id="input" value\$="{{inputValue}}">
@@ -582,7 +582,7 @@ Polymer({
   is: 'x-input-value'
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="check">{{isAttached}}</div>
@@ -600,7 +600,7 @@ Polymer({
 });
 var invocations = [];
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-order-of-effects id="child" base="{{base}}"></x-order-of-effects>
@@ -620,7 +620,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-order-of-effects-child prop1="[[base]]" prop2="[[_computedAnnotation(base)]]"></x-order-of-effects-child>
@@ -672,7 +672,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-order-of-effects-child',
 
   properties: {
@@ -693,7 +693,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="check">[[translateMessage('Hello World.')]]</div>
@@ -728,7 +728,7 @@ var TranslateBehavior = {
   }
 };
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div id="check">[[translateMessage(message)]]</div>
@@ -757,7 +757,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <div -u-p-c-a-s-e\$="[[UPCASE]]"></div>
@@ -773,7 +773,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <template is="dom-if" if="[[visible]]">
@@ -799,7 +799,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-propagate',
 
   properties: {
@@ -827,8 +827,8 @@ Polymer({
   }
 });
 class XRaw extends HTMLElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   constructor() {
@@ -869,7 +869,7 @@ class XRaw extends HTMLElement {
 customElements.define('x-raw', XRaw);
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-polymer',
 
   created: function() {
@@ -890,7 +890,7 @@ Polymer({
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-polymer id="polymer" array="{{array}}" compound="**{{array}}**">{{array}}</x-polymer>
@@ -912,7 +912,7 @@ Polymer({
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-template-proto',
 
   _template: (function() {
@@ -945,13 +945,13 @@ let TemplateBehavior = {
 };
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-template-behavior',
   behaviors: [TemplateBehavior]
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-immutable-b b="[[a.b]]" x="[[a.x]]" id="b"></x-immutable-b>
@@ -966,8 +966,8 @@ Polymer({
   }
 });
 class XImmutableB extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {
@@ -987,7 +987,7 @@ class XImmutableB extends PolymerElement {
 }
 customElements.define('x-immutable-b', XImmutableB);
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-immutable-c',
   observers: ['cChanged(c)', 'xChanged(x)'],
 
@@ -997,7 +997,7 @@ Polymer({
   }
 });
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-mutable-b b="[[a.b]]" x="[[a.x]]" id="b"></x-mutable-b>
@@ -1013,8 +1013,8 @@ Polymer({
   }
 });
 class XMutableB extends MutableData(PolymerElement) {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {
@@ -1034,7 +1034,7 @@ class XMutableB extends MutableData(PolymerElement) {
 }
 customElements.define('x-mutable-b', XMutableB);
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-mutable-c',
   behaviors: [MutableDataBehavior],
   observers: ['cChanged(c)', 'xChanged(x)'],
@@ -1045,8 +1045,8 @@ Polymer({
   }
 });
 class SVGElement extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {

--- a/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
@@ -15,8 +15,8 @@ $_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = `<dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>`;
 document.head.appendChild($_documentContainer.content);
 class PR extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get template() {
@@ -49,8 +49,8 @@ class PR extends PolymerElement {
 }
 customElements.define(PR.is, PR);
 class PRAp extends PolymerElement {
-  static get importPath() {
-    return import.meta.url;
+  static get importMeta() {
+    return import.meta;
   }
 
   static get is() { return 'p-r-ap'; }

--- a/fixtures/packages/polymer/expected/test/unit/templatize-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/templatize-elements.js
@@ -14,7 +14,7 @@ import { Templatizer } from '../../lib/legacy/templatizer-behavior.js';
 import { html } from '../../lib/utils/html-tag.js';
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-child',
 
   properties: {
@@ -51,7 +51,7 @@ Polymer({
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-templatize',
 
   properties: {
@@ -112,7 +112,7 @@ Polymer({
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
   is: 'x-templatize-behavior',
 
   properties: {
@@ -178,7 +178,7 @@ Polymer({
 });
 
 Polymer({
-  importPath: import.meta.url,
+  importMeta: import.meta,
 
   _template: html`
     <x-templatize obj="{{objA}}" prop="{{propA}}" id="templatizeA">

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -110,7 +110,7 @@ export default async function run(options: CliOptions) {
     packageName: npmPackageName.toLowerCase(),
     packageVersion: npmPackageVersion,
     cleanOutDir: options.clean!!,
-    removeImportMeta: options['remove-import-meta'],
+    addImportMeta: options['add-import-meta'],
     flat: options.flat,
     private: options.private,
     packageType: options['package-type']

--- a/src/cli/command-package.ts
+++ b/src/cli/command-package.ts
@@ -110,7 +110,7 @@ export default async function run(options: CliOptions) {
     packageName: npmPackageName.toLowerCase(),
     packageVersion: npmPackageVersion,
     cleanOutDir: options.clean!!,
-    addImportPath: options['add-import-path'],
+    removeImportMeta: options['remove-import-meta'],
     flat: options.flat,
     private: options.private,
     packageType: options['package-type']

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -146,7 +146,7 @@ export default async function run(options: CliOptions) {
     deleteFiles: options['delete-files'],
     flat: options.flat,
     private: options.private,
-    addImportPath: options['add-import-path'],
+    removeImportMeta: options['remove-import-meta'],
     excludes: options.exclude,
   });
 

--- a/src/cli/command-workspace.ts
+++ b/src/cli/command-workspace.ts
@@ -146,7 +146,7 @@ export default async function run(options: CliOptions) {
     deleteFiles: options['delete-files'],
     flat: options.flat,
     private: options.private,
-    removeImportMeta: options['remove-import-meta'],
+    addImportMeta: options['add-import-meta'],
     excludes: options.exclude,
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,11 +158,11 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
         `Defaults to "path".`,
   },
   {
-    name: 'remove-import-meta',
+    name: 'add-import-meta',
     type: Boolean,
-    defaultValue: false,
-    description: `Whether to not add a static importMeta property to ` +
-        `elements. Defaults to false`,
+    defaultValue: true,
+    description: `Whether to add a static importMeta property to ` +
+        `elements. Defaults to true`,
   },
   {
     name: 'flat',
@@ -209,7 +209,7 @@ export interface CliOptions {
   push: boolean;
   publish: boolean;
   'import-style': NpmImportStyle;
-  'remove-import-meta': boolean;
+  'add-import-meta': boolean;
   flat: boolean;
   'private': boolean;
   'package-type': PackageType;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,11 +158,11 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
         `Defaults to "path".`,
   },
   {
-    name: 'add-import-path',
+    name: 'remove-import-meta',
     type: Boolean,
     defaultValue: false,
-    description: `Whether to add a static importPath property to elements. ` +
-        `Defaults to false`,
+    description: `Whether to not add a static importMeta property to ` +
+        `elements. Defaults to false`,
   },
   {
     name: 'flat',
@@ -209,7 +209,7 @@ export interface CliOptions {
   push: boolean;
   publish: boolean;
   'import-style': NpmImportStyle;
-  'add-import-path': boolean;
+  'remove-import-meta': boolean;
   flat: boolean;
   'private': boolean;
   'package-type': PackageType;

--- a/src/conversion-settings.ts
+++ b/src/conversion-settings.ts
@@ -74,10 +74,10 @@ export interface ConversionSettings {
   readonly npmImportStyle: NpmImportStyle;
 
   /**
-   * Whether to add the static importPath property (set to import.meta.url)
+   * Whether to add the static importMeta static property (set to import.meta)
    * to elements.
    */
-  readonly addImportPath: boolean;
+  readonly removeImportMeta: boolean;
 }
 
 /**
@@ -122,10 +122,10 @@ export interface PartialConversionSettings {
   readonly npmImportStyle?: NpmImportStyle;
 
   /**
-   * Whether to add the static importPath property (set to import.meta.url)
-   * to elements.
+   * Whether to add the static importMeta property (set to import.meta) to
+   * elements.
    */
-  readonly addImportPath?: boolean;
+  readonly removeImportMeta?: boolean;
 
   /**
    * After conversion, delete all files/directories that match any of these
@@ -200,7 +200,7 @@ export function createDefaultConversionSettings(
   const npmImportStyle = options.npmImportStyle || 'path';
 
   // Configure "npmImportStyle", defaults to false
-  const addImportPath = options.addImportPath === true;
+  const removeImportMeta = options.removeImportMeta === true;
 
   // Return configured settings.
   return {
@@ -210,6 +210,6 @@ export function createDefaultConversionSettings(
     referenceExcludes,
     referenceRewrites,
     npmImportStyle,
-    addImportPath,
+    removeImportMeta,
   };
 }

--- a/src/conversion-settings.ts
+++ b/src/conversion-settings.ts
@@ -77,7 +77,7 @@ export interface ConversionSettings {
    * Whether to add the static importMeta static property (set to import.meta)
    * to elements.
    */
-  readonly removeImportMeta: boolean;
+  readonly addImportMeta: boolean;
 }
 
 /**
@@ -125,7 +125,7 @@ export interface PartialConversionSettings {
    * Whether to add the static importMeta property (set to import.meta) to
    * elements.
    */
-  readonly removeImportMeta?: boolean;
+  readonly addImportMeta?: boolean;
 
   /**
    * After conversion, delete all files/directories that match any of these
@@ -200,7 +200,7 @@ export function createDefaultConversionSettings(
   const npmImportStyle = options.npmImportStyle || 'path';
 
   // Configure "npmImportStyle", defaults to false
-  const removeImportMeta = options.removeImportMeta === true;
+  const addImportMeta = options.addImportMeta === true;
 
   // Return configured settings.
   return {
@@ -210,6 +210,6 @@ export function createDefaultConversionSettings(
     referenceExcludes,
     referenceRewrites,
     npmImportStyle,
-    removeImportMeta,
+    addImportMeta,
   };
 }

--- a/src/document-processor.ts
+++ b/src/document-processor.ts
@@ -155,7 +155,7 @@ export abstract class DocumentProcessor {
       for (const claimedDomModule of localClaimedDomModules) {
         claimedDomModules.add(claimedDomModule);
       }
-      if (!this.conversionSettings.removeImportMeta) {
+      if (this.conversionSettings.addImportMeta) {
         this.addImportMetaToElements(scriptProgram, scriptDocument);
       }
       const statements = scriptProgram.body;

--- a/src/test/fixtures/run-fixture.ts
+++ b/src/test/fixtures/run-fixture.ts
@@ -36,6 +36,5 @@ export async function runFixture(
     '--out',
     '.',
     '--force',
-    '--add-import-path',
   ].concat(testConfig.options || []));
 }

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -94,7 +94,7 @@ suite('AnalysisConverter', () => {
         excludes: partialOptions.excludes,
         referenceExcludes: partialOptions.referenceExcludes,
         npmImportStyle: partialOptions.npmImportStyle,
-        removeImportMeta: partialOptions.removeImportMeta,
+        addImportMeta: partialOptions.addImportMeta,
         flat: false,
         private: false,
         packageEntrypoints,
@@ -1596,10 +1596,6 @@ import { html } from './html-tag.js';
  * @polymer
  */
 class TestElement extends Element {
-  static get importMeta() {
-    return import.meta;
-  }
-
   static get template() {
     return html\`
     <h1>Hi!</h1>
@@ -1651,8 +1647,6 @@ class TestElement extends Element {
 import { Polymer } from './polymer.js';
 import { html } from './html-tag.js';
 Polymer({
-  importMeta: import.meta,
-
   _template: html\`
       <h1>Hi!</h1>
 \`,
@@ -1678,7 +1672,7 @@ Polymer({
       });
       assertSources(
           await convert({
-            removeImportMeta: true,
+            addImportMeta: true,
           }),
           {
             'test.js': `
@@ -1687,6 +1681,9 @@ Polymer({
  * @polymer
  */
 class TestElement extends Polymer.Element {
+  static get importMeta() {
+    return import.meta;
+  }
 }
 `
           });
@@ -1704,11 +1701,12 @@ class TestElement extends Polymer.Element {
 
       assertSources(
           await convert({
-            removeImportMeta: true,
+            addImportMeta: true,
           }),
           {
             'test.js': `
 Polymer({
+  importMeta: import.meta
 });
 `
           });
@@ -2007,10 +2005,6 @@ $_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = \`<div>Random footer</div>\`;
 document.head.appendChild($_documentContainer.content);
 customElements.define('foo-elem', class FooElem extends Element {
-  static get importMeta() {
-    return import.meta;
-  }
-
   static get template() {
     return Polymer.html\`
     <div>foo-element body</div>
@@ -2018,10 +2012,6 @@ customElements.define('foo-elem', class FooElem extends Element {
   }
 });
 customElements.define('bar-elem', class BarElem extends Element {
-  static get importMeta() {
-    return import.meta;
-  }
-
   static get template() {
     return Polymer.html\`
     <div>bar body</div>
@@ -2293,8 +2283,6 @@ console.log(ShadyDOM.flush());
       assertSources(await convert(), {
         'test.js': `
 Polymer({
-  importMeta: import.meta,
-
   _template: Polymer.html\`
 foo
 \`,
@@ -2302,8 +2290,6 @@ foo
   is: 'foo'
 });
 Polymer({
-  importMeta: import.meta,
-
   _template: Polymer.html\`
 bar
 \`,
@@ -2554,10 +2540,6 @@ console.log(foo);
           {
             'test.js': `
 class XFoo extends HTMLElement {
-  static get importMeta() {
-    return import.meta;
-  }
-
   connectedCallback() {
     this.spy = sinon.spy(window.ShadyCSS, 'styleElement');
     super.connectedCallback();
@@ -2567,7 +2549,6 @@ class XFoo extends HTMLElement {
 customElements.define('x-foo', XFoo);
 
 Polymer({
-  importMeta: import.meta,
   is: 'data-popup'
 });
 `,
@@ -2999,17 +2980,9 @@ $_documentContainer.innerHTML = \`<dom-module id="dom-module-attr" attr=""></dom
 
 document.head.appendChild($_documentContainer.content);
 customElements.define(
-    'dom-module-attr', class extends HTMLElement{
-  static get importMeta() {
-    return import.meta;
-  }
-});
+    'dom-module-attr', class extends HTMLElement{});
 customElements.define(
     'just-fine', class extends HTMLElement{
-  static get importMeta() {
-    return import.meta;
-  }
-
   static get template() {
     return Polymer.html\`
 Hello world
@@ -3017,11 +2990,7 @@ Hello world
   }
 });
 customElements.define(
-    'multiple-templates', class extends HTMLElement{
-  static get importMeta() {
-    return import.meta;
-  }
-});
+    'multiple-templates', class extends HTMLElement{});
 `,
       });
     });
@@ -3578,8 +3547,6 @@ console.log('main file contents');
         assertSources(await convert(), {
           'test.js': `
 Polymer({
-  importMeta: import.meta,
-
   _template: Polymer.html\`
             <div>Implementation here</div>
 \`,

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -94,7 +94,7 @@ suite('AnalysisConverter', () => {
         excludes: partialOptions.excludes,
         referenceExcludes: partialOptions.referenceExcludes,
         npmImportStyle: partialOptions.npmImportStyle,
-        addImportPath: partialOptions.addImportPath,
+        removeImportMeta: partialOptions.removeImportMeta,
         flat: false,
         private: false,
         packageEntrypoints,
@@ -1596,6 +1596,10 @@ import { html } from './html-tag.js';
  * @polymer
  */
 class TestElement extends Element {
+  static get importMeta() {
+    return import.meta;
+  }
+
   static get template() {
     return html\`
     <h1>Hi!</h1>
@@ -1647,6 +1651,8 @@ class TestElement extends Element {
 import { Polymer } from './polymer.js';
 import { html } from './html-tag.js';
 Polymer({
+  importMeta: import.meta,
+
   _template: html\`
       <h1>Hi!</h1>
 \`,
@@ -1657,7 +1663,7 @@ Polymer({
       });
     });
 
-    test('adds importPath to class-based Polymer elements', async () => {
+    test('adds importMeta to class-based Polymer elements', async () => {
       setSources({
         'test.html': `
 <script>
@@ -1672,7 +1678,7 @@ Polymer({
       });
       assertSources(
           await convert({
-            addImportPath: true,
+            removeImportMeta: true,
           }),
           {
             'test.js': `
@@ -1681,15 +1687,12 @@ Polymer({
  * @polymer
  */
 class TestElement extends Polymer.Element {
-  static get importPath() {
-    return import.meta.url;
-  }
 }
 `
           });
     });
 
-    test('adds importPath to class-based Polymer elements', async () => {
+    test('adds importMeta to class-based Polymer elements', async () => {
       setSources({
         'test.html': `
 <script>
@@ -1701,12 +1704,11 @@ class TestElement extends Polymer.Element {
 
       assertSources(
           await convert({
-            addImportPath: true,
+            removeImportMeta: true,
           }),
           {
             'test.js': `
 Polymer({
-  importPath: import.meta.url
 });
 `
           });
@@ -2005,6 +2007,10 @@ $_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = \`<div>Random footer</div>\`;
 document.head.appendChild($_documentContainer.content);
 customElements.define('foo-elem', class FooElem extends Element {
+  static get importMeta() {
+    return import.meta;
+  }
+
   static get template() {
     return Polymer.html\`
     <div>foo-element body</div>
@@ -2012,6 +2018,10 @@ customElements.define('foo-elem', class FooElem extends Element {
   }
 });
 customElements.define('bar-elem', class BarElem extends Element {
+  static get importMeta() {
+    return import.meta;
+  }
+
   static get template() {
     return Polymer.html\`
     <div>bar body</div>
@@ -2283,6 +2293,8 @@ console.log(ShadyDOM.flush());
       assertSources(await convert(), {
         'test.js': `
 Polymer({
+  importMeta: import.meta,
+
   _template: Polymer.html\`
 foo
 \`,
@@ -2290,6 +2302,8 @@ foo
   is: 'foo'
 });
 Polymer({
+  importMeta: import.meta,
+
   _template: Polymer.html\`
 bar
 \`,
@@ -2540,6 +2554,10 @@ console.log(foo);
           {
             'test.js': `
 class XFoo extends HTMLElement {
+  static get importMeta() {
+    return import.meta;
+  }
+
   connectedCallback() {
     this.spy = sinon.spy(window.ShadyCSS, 'styleElement');
     super.connectedCallback();
@@ -2549,6 +2567,7 @@ class XFoo extends HTMLElement {
 customElements.define('x-foo', XFoo);
 
 Polymer({
+  importMeta: import.meta,
   is: 'data-popup'
 });
 `,
@@ -2980,9 +2999,17 @@ $_documentContainer.innerHTML = \`<dom-module id="dom-module-attr" attr=""></dom
 
 document.head.appendChild($_documentContainer.content);
 customElements.define(
-    'dom-module-attr', class extends HTMLElement{});
+    'dom-module-attr', class extends HTMLElement{
+  static get importMeta() {
+    return import.meta;
+  }
+});
 customElements.define(
     'just-fine', class extends HTMLElement{
+  static get importMeta() {
+    return import.meta;
+  }
+
   static get template() {
     return Polymer.html\`
 Hello world
@@ -2990,7 +3017,11 @@ Hello world
   }
 });
 customElements.define(
-    'multiple-templates', class extends HTMLElement{});
+    'multiple-templates', class extends HTMLElement{
+  static get importMeta() {
+    return import.meta;
+  }
+});
 `,
       });
     });
@@ -3547,6 +3578,8 @@ console.log('main file contents');
         assertSources(await convert(), {
           'test.js': `
 Polymer({
+  importMeta: import.meta,
+
   _template: Polymer.html\`
             <div>Implementation here</div>
 \`,


### PR DESCRIPTION
Removed `--add-import-path` and changed it to `--remove-import-meta`. It might be useful to look at the individual commits to filter out all the tests

**before:**
The flag, `--add-import-meta`, that defaulted to `false`, would add
```js
class extends PolymerElement {
  static get importPath() { return import.meta.url; }
}

Polymer({
  importPath: import.meta.url
});
```
This was no longer supported in Polymer/polymer#5180

**after:**
The flag is now `--remove-import-meta` (`false` by default). So, by default we insert:
```js
class extends PolymerElement {
  static get importMeta() { return import.meta; }
}

Polymer({
  importMeta: import.meta
});
```
By adding the `--remove-import-meta` flag, the user can opt out of this insertion (which is now on by default).