### PR TITLE
Update yarn resolution for webcomponentsjs to 2.0.0

### DIFF
--- a/fixtures/packages/iron-icon/expected/package.json
+++ b/fixtures/packages/iron-icon/expected/package.json
@@ -31,7 +31,7 @@
     "samsam": "1.1.3",
     "supports-color": "3.1.2",
     "type-detect": "1.0.0",
-    "@webcomponents/webcomponentsjs": "2.0.0-beta.2"
+    "@webcomponents/webcomponentsjs": "2.0.0"
   },
   "main": "iron-icon.js",
   "author": "The Polymer Authors",

--- a/fixtures/packages/paper-button/expected/package.json
+++ b/fixtures/packages/paper-button/expected/package.json
@@ -35,7 +35,7 @@
     "samsam": "1.1.3",
     "supports-color": "3.1.2",
     "type-detect": "1.0.0",
-    "@webcomponents/webcomponentsjs": "2.0.0-beta.2"
+    "@webcomponents/webcomponentsjs": "2.0.0"
   },
   "main": "paper-button.js",
   "author": "The Polymer Authors",

--- a/fixtures/packages/polymer/expected/package.json
+++ b/fixtures/packages/polymer/expected/package.json
@@ -61,7 +61,7 @@
     "samsam": "1.1.3",
     "supports-color": "3.1.2",
     "type-detect": "1.0.0",
-    "@webcomponents/webcomponentsjs": "2.0.0-beta.2"
+    "@webcomponents/webcomponentsjs": "2.0.0"
   },
   "dependencies": {
     "@webcomponents/shadycss": "^1.0.0",

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -155,7 +155,7 @@ export function generatePackageJson(
     'samsam': '1.1.3',
     'supports-color': '3.1.2',
     'type-detect': '1.0.0',
-    '@webcomponents/webcomponentsjs': '2.0.0-beta.2'
+    '@webcomponents/webcomponentsjs': '2.0.0'
   };
 
   if (!packageJson.main) {


### PR DESCRIPTION
This is still needed because of the [wct-browser-legacy](https://github.com/Polymer/tools/blob/master/packages/web-component-tester/wct-browser-legacy/package.json#L31) depending on the `^1.0.7` version. Releasing `wct-browser-legacy` 1.0.0 would be a perfect moment to bump that dependency. Still I think you have to cut a new release, and until that time we have to keep this resolution here.

/cc @usergenic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-modulizer/426)
<!-- Reviewable:end -->
