### PR TITLE
Bump wct-browser-legacy mapping, remove webcomponentsjs resolution

### DIFF
--- a/dependency-map.json
+++ b/dependency-map.json
@@ -505,7 +505,7 @@
   },
   "web-component-tester": {
     "npm": "wct-browser-legacy",
-    "semver": "^0.0.1-pre.11"
+    "semver": "^1.0.1"
   },
   "web-animations-js": {
     "npm": "web-animations-js",

--- a/fixtures/packages/iron-icon/expected/package.json
+++ b/fixtures/packages/iron-icon/expected/package.json
@@ -18,7 +18,7 @@
     "@polymer/iron-iconset": "^3.0.0-pre.18",
     "@polymer/iron-icons": "^3.0.0-pre.18",
     "@polymer/iron-component-page": "^3.0.0-pre.18",
-    "wct-browser-legacy": "^0.0.1-pre.11",
+    "wct-browser-legacy": "^1.0.1",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "@polymer/iron-demo-helpers": "^3.0.0-pre.18"
   },
@@ -30,8 +30,7 @@
     "inherits": "2.0.3",
     "samsam": "1.1.3",
     "supports-color": "3.1.2",
-    "type-detect": "1.0.0",
-    "@webcomponents/webcomponentsjs": "2.0.0-beta.2"
+    "type-detect": "1.0.0"
   },
   "main": "iron-icon.js",
   "author": "The Polymer Authors",

--- a/fixtures/packages/paper-button/expected/package.json
+++ b/fixtures/packages/paper-button/expected/package.json
@@ -23,7 +23,7 @@
     "@polymer/iron-icons": "^3.0.0-pre.18",
     "@polymer/iron-test-helpers": "^3.0.0-pre.18",
     "@polymer/test-fixture": "^3.0.0-pre.18",
-    "wct-browser-legacy": "^0.0.1-pre.11",
+    "wct-browser-legacy": "^1.0.1",
     "@webcomponents/webcomponentsjs": "^2.0.0"
   },
   "scripts": {
@@ -34,8 +34,7 @@
     "inherits": "2.0.3",
     "samsam": "1.1.3",
     "supports-color": "3.1.2",
-    "type-detect": "1.0.0",
-    "@webcomponents/webcomponentsjs": "2.0.0-beta.2"
+    "type-detect": "1.0.0"
   },
   "main": "paper-button.js",
   "author": "The Polymer Authors",

--- a/fixtures/packages/polymer/expected/package.json
+++ b/fixtures/packages/polymer/expected/package.json
@@ -37,7 +37,7 @@
     "run-sequence": "^2.2.0",
     "through2": "^2.0.0",
     "web-component-tester": "^6.5.0",
-    "wct-browser-legacy": "^0.0.1-pre.11",
+    "wct-browser-legacy": "^1.0.1",
     "@polymer/test-fixture": "^3.0.0-pre.18",
     "@polymer/iron-component-page": "^3.0.0-pre.18"
   },
@@ -60,8 +60,7 @@
     "inherits": "2.0.3",
     "samsam": "1.1.3",
     "supports-color": "3.1.2",
-    "type-detect": "1.0.0",
-    "@webcomponents/webcomponentsjs": "2.0.0-beta.2"
+    "type-detect": "1.0.0"
   },
   "dependencies": {
     "@webcomponents/shadycss": "^1.0.0",

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -154,8 +154,7 @@ export function generatePackageJson(
     'inherits': '2.0.3',
     'samsam': '1.1.3',
     'supports-color': '3.1.2',
-    'type-detect': '1.0.0',
-    '@webcomponents/webcomponentsjs': '2.0.0-beta.2'
+    'type-detect': '1.0.0'
   };
 
   if (!packageJson.main) {


### PR DESCRIPTION
`wct-browser-legacy` 1.0.1 no longer depends on the `webcomponentsjs` 1.x

See also Polymer/tools#397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-modulizer/442)
<!-- Reviewable:end -->
