### PR TITLE
Use html-tag for inserting templates to document

### DIFF
--- a/fixtures/packages/iron-icon/expected/demo/index.html
+++ b/fixtures/packages/iron-icon/expected/demo/index.html
@@ -27,9 +27,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         See: https://github.com/Polymer/polymer-modulizer/issues/154
         -->
     <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<custom-style>
+const $_documentContainer = html`<custom-style>
     <style is="custom-style" include="demo-pages-shared-styles"></style>
   </custom-style>`;
 
@@ -37,9 +37,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
+const $_documentContainer = html`<div class="vertical-section-container centered">
     <h3>
       This demo is for a single &lt;iron-icon&gt;. If you're looking for the
       whole set of available icons, check out the

--- a/fixtures/packages/paper-button/expected/demo/index.html
+++ b/fixtures/packages/paper-button/expected/demo/index.html
@@ -34,9 +34,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         See: https://github.com/Polymer/polymer-modulizer/issues/154
         -->
     <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<custom-style>
+const $_documentContainer = html`<custom-style>
     <style is="custom-style" include="demo-pages-shared-styles">
       .vertical-section-container {
         max-width: 500px;
@@ -53,9 +53,9 @@ document.body.appendChild($_documentContainer.content);
 </head>
 <body unresolved>
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
+const $_documentContainer = html`<div class="vertical-section-container centered">
     <h3>Buttons can be flat, raised, toggleable, or disabled</h3>
     <demo-snippet class="centered-demo">
       <template>

--- a/fixtures/packages/paper-button/expected/paper-button.js
+++ b/fixtures/packages/paper-button/expected/paper-button.js
@@ -85,10 +85,9 @@ import '../../@polymer/iron-flex-layout/iron-flex-layout.js';
 import { PaperButtonBehavior, PaperButtonBehaviorImpl } from '../../@polymer/paper-behaviors/paper-button-behavior.js';
 import '../../@polymer/paper-styles/element-styles/paper-material-styles.js';
 import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="paper-button">
+const $_documentContainer = html`<dom-module id="paper-button">
   <template strip-whitespace="">
     <style include="paper-material-styles">
       /* Need to specify the same specificity as the styles imported from paper-material. */

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements-defaults.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements-defaults.js
@@ -1,7 +1,6 @@
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '../../../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<style is="custom-style">
+const $_documentContainer = html`<style is="custom-style">
   html {
     --x-s: {
       display: inline-block;

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
@@ -1,9 +1,7 @@
 import { Polymer } from '../../../../lib/legacy/polymer-fn.js';
 import { html } from '../../../../lib/utils/html-tag.js';
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
-$_documentContainer.innerHTML = `<dom-module id="simple-layout-styles">
+const $_documentContainer = html`<dom-module id="simple-layout-styles">
   <template>
     <style>
       .horizontal.layout {

--- a/fixtures/packages/polymer/expected/test/unit/custom-style-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style-import.js
@@ -1,8 +1,7 @@
 import './sub/style-import.js';
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="shared-style">
+const $_documentContainer = html`<dom-module id="shared-style">
   <template>
     <style>
       html {

--- a/fixtures/packages/polymer/expected/test/unit/custom-style.html
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style.html
@@ -26,9 +26,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         See: https://github.com/Polymer/polymer-modulizer/issues/154
         -->
     <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<custom-style>
+const $_documentContainer = html`<custom-style>
   <style is="custom-style">
     x-bar {
       border: 1px solid red;
@@ -81,9 +81,9 @@ $_documentContainer.innerHTML = `<custom-style>
 document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<custom-style>
+const $_documentContainer = html`<custom-style>
   <style is="custom-style">
     .bag {
       ;@apply --bag;
@@ -116,9 +116,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
 <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<custom-style>
+const $_documentContainer = html`<custom-style>
   <style is="custom-style" include="shared-style2">
     .zazz {
       border: 20px solid blue;
@@ -134,9 +134,9 @@ $_documentContainer.innerHTML = `<custom-style>
 document.body.appendChild($_documentContainer.content);
 </script>
 <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<custom-style>
+const $_documentContainer = html`<custom-style>
   <style is="custom-style">
     @media (min-width: 1px) {
       .foo--bar {
@@ -149,99 +149,115 @@ $_documentContainer.innerHTML = `<custom-style>
 document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="italic">italic</div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div class="italic">italic</div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="bag">bag</div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div class="bag">bag</div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="mix">mix</div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div class="mix">mix</div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="dynamic">dynamic</div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div class="dynamic">dynamic</div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="import-mixin">import-mixin</div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div class="import-mixin">import-mixin</div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="import-var">import-var</div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div class="import-var">import-var</div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<x-bar></x-bar>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<x-bar></x-bar>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<x-foo></x-foo>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<x-foo></x-foo>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<x-red-text></x-red-text>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<x-red-text></x-red-text>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<x-blue-bold-text></x-blue-bold-text>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<x-blue-bold-text></x-blue-bold-text>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<parent-variable-with-var></parent-variable-with-var>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<parent-variable-with-var></parent-variable-with-var>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<br>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<br>`;
 document.body.appendChild($_documentContainer.content);
 </script><script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<br>`;
-document.body.appendChild($_documentContainer.content);
-</script>
-  <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div id="after"></div>`;
-document.body.appendChild($_documentContainer.content);
-</script>
+  import { html } from '../../lib/utils/html-tag.js';
 
+const $_documentContainer = html`<br>`;
+document.body.appendChild($_documentContainer.content);
+</script>
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="foo"></div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div id="after"></div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<div class="foo--bar"></div>`;
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<div class="foo"></div>`;
 document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="x-baz">
+const $_documentContainer = html`<div class="foo--bar"></div>`;
+document.body.appendChild($_documentContainer.content);
+</script>
+
+  <script type="module">
+import { html } from '../../lib/utils/html-tag.js';
+
+const $_documentContainer = html`<dom-module id="x-baz">
     <template>
     <style>
       :host {
@@ -256,9 +272,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="x-bar">
+const $_documentContainer = html`<dom-module id="x-bar">
     <template>
     <style>
       :host {
@@ -274,9 +290,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="x-foo">
+const $_documentContainer = html`<dom-module id="x-foo">
     <template>
     <style>
       :host {
@@ -305,9 +321,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="x-red-text">
+const $_documentContainer = html`<dom-module id="x-red-text">
     <template>
     <style>
       :host {
@@ -322,9 +338,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="x-blue-bold-text">
+const $_documentContainer = html`<dom-module id="x-blue-bold-text">
     <template>
     <style>
       :host {@apply --blue-text;@apply --bold-text;}
@@ -337,9 +353,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="parent-variable-with-var">
+const $_documentContainer = html`<dom-module id="parent-variable-with-var">
     <template>
       <style>
         child-variable-with-var {
@@ -362,9 +378,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="child-variable-with-var">
+const $_documentContainer = html`<dom-module id="child-variable-with-var">
     <template>
       <style>
         child-of-child-with-var {
@@ -390,9 +406,9 @@ document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="child-of-child-with-var">
+const $_documentContainer = html`<dom-module id="child-of-child-with-var">
     <template>
       <style>
         :host {

--- a/fixtures/packages/polymer/expected/test/unit/shady-unscoped-style-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/shady-unscoped-style-import.js
@@ -1,7 +1,6 @@
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '../../lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = `<dom-module id="global-shared1">
+const $_documentContainer = html`<dom-module id="global-shared1">
   
   <template>
     <style shady-unscoped="">

--- a/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
@@ -10,9 +10,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import { html } from '../../../lib/utils/html-tag.js';
 
 import { PolymerElement } from '../../../polymer-element.js';
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
-$_documentContainer.innerHTML = `<dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>`;
+
+const $_documentContainer = html`<dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>`;
 document.head.appendChild($_documentContainer.content);
 class PR extends PolymerElement {
   static get template() {

--- a/src/document-util.ts
+++ b/src/document-util.ts
@@ -530,24 +530,17 @@ export function createDomNodeInsertStatements(
   };
   const templateValue = serializeNodeToTemplateLiteral(fragment as any, false);
 
-  const createElementDiv = jsc.variableDeclaration(
+  const createTemplateTag = jsc.variableDeclaration(
       'const',
       [jsc.variableDeclarator(
           jsc.identifier(varName),
-          jsc.callExpression(
+          jsc.taggedTemplateExpression(
               jsc.memberExpression(
-                  jsc.identifier('document'), jsc.identifier('createElement')),
-              [jsc.literal('template')]))]);
-  const setDocumentContainerStatement =
-      jsc.expressionStatement(jsc.assignmentExpression(
-          '=',
-          jsc.memberExpression(
-              jsc.identifier(varName), jsc.identifier('innerHTML')),
-          templateValue));
+                  jsc.identifier('Polymer'), jsc.identifier('html')),
+                  templateValue))]);
   if (activeInBody) {
     return [
-      createElementDiv,
-      setDocumentContainerStatement,
+      createTemplateTag,
       jsc.expressionStatement(jsc.callExpression(
           jsc.memberExpression(
               jsc.memberExpression(
@@ -557,14 +550,8 @@ export function createDomNodeInsertStatements(
               jsc.identifier(varName), jsc.identifier('content'))]))
     ];
   }
-  const setDisplayNoneStatement = jsc.expressionStatement(jsc.callExpression(
-      jsc.memberExpression(
-          jsc.identifier(varName), jsc.identifier('setAttribute')),
-      [jsc.literal('style'), jsc.literal('display: none;')]));
   return [
-    createElementDiv,
-    setDisplayNoneStatement,
-    setDocumentContainerStatement,
+    createTemplateTag,
     jsc.expressionStatement(jsc.callExpression(
         jsc.memberExpression(
             jsc.memberExpression(

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -1723,15 +1723,15 @@ Polymer({
       assertSources(await convert(), {
         'test.js': `
 import './foo.js';
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
-$_documentContainer.innerHTML = \`<custom-style><style>foo{}</style></custom-style>\`;
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+const $_documentContainer = html\`<custom-style><style>foo{}</style></custom-style>\`;
 document.head.appendChild($_documentContainer.content);
 `,
         'foo.js': `
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
-$_documentContainer.innerHTML = \`<div>hello world!</div>\`;
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+const $_documentContainer = html\`<div>hello world!</div>\`;
 document.head.appendChild($_documentContainer.content);
 `
       });
@@ -1959,9 +1959,9 @@ class BarElem extends Element {}
       assertSources(await convert(), {
         'test.js': `
 import { Element } from './polymer.js';
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
-$_documentContainer.innerHTML = \`<div>Top</div><div>Middle</div><div>Bottom</div>\`;
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+const $_documentContainer = html\`<div>Top</div><div>Middle</div><div>Bottom</div>\`;
 document.head.appendChild($_documentContainer.content);
 class FooElem extends Element {}
 class BarElem extends Element {}
@@ -2000,9 +2000,9 @@ class BarElem extends Element {}
       assertSources(await convert(), {
         'test.js': `
 import { Element } from './polymer.js';
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
-$_documentContainer.innerHTML = \`<div>Random footer</div>\`;
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+const $_documentContainer = html\`<div>Random footer</div>\`;
 document.head.appendChild($_documentContainer.content);
 customElements.define('foo-elem', class FooElem extends Element {
   static get template() {
@@ -2578,10 +2578,9 @@ Polymer({
           }),
           {
             'test.js': `
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = \`<dom-module>
+const $_documentContainer = html\`<dom-module>
             <template>
               Scripts in here are cloned
               <script>foo&lt;/script>
@@ -2712,29 +2711,27 @@ console.log(foo$4);
         See: https://github.com/Polymer/polymer-modulizer/issues/154
         -->
     <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = \`<style>
+const $_documentContainer = html\`<style>
             body { color: red; }
           </style>\`;
 
 document.head.appendChild($_documentContainer.content);
 </script>
           <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = \`<style is="custom-style" include="foo-bar">
+const $_documentContainer = html\`<style is="custom-style" include="foo-bar">
             body { font-size: 10px; }
           </style>\`;
 
 document.head.appendChild($_documentContainer.content);
 </script>
           <script type="module">
-const $_documentContainer = document.createElement('template');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = \`<custom-style>
+const $_documentContainer = html\`<custom-style>
             <style is="custom-style">
               body { background-color: var(--happy, yellow); }
             </style>
@@ -2743,8 +2740,9 @@ $_documentContainer.innerHTML = \`<custom-style>
 document.body.appendChild($_documentContainer.content);
 </script>
           <script type="module">
-const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = \`<foo-elem></foo-elem>\`;
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+const $_documentContainer = html\`<foo-elem></foo-elem>\`;
 document.body.appendChild($_documentContainer.content);
 </script>
         `
@@ -2970,10 +2968,9 @@ export const bar = (function() {
       });
       assertSources(await convert(), {
         'test.js': `
-const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-$_documentContainer.innerHTML = \`<dom-module id="dom-module-attr" attr=""></dom-module><dom-module id="multiple-templates">
+const $_documentContainer = html\`<dom-module id="dom-module-attr" attr=""></dom-module><dom-module id="multiple-templates">
             <template></template>
             <template></template>
           </dom-module>\`;


### PR DESCRIPTION
Fixes #449 

Tests are currently failing, because we need to somehow add the import declaration to documents, e. g. to `demo/index.html` for the `hasIncludedStyle` case, and also for demo snippets.

@bicknellr could you point me to the right direction about how do I add the following import?
```js
import { html } from '@polymer/polymer/lib/utils/html-tag.js'
```

Maybe we could leave the current mechanism as is for files not converted to `.js` (e.g. demos), but for the converted files it would be nice to have this option. WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-modulizer/450)
<!-- Reviewable:end -->
