### PR TITLE
Do not set display: none for template elements

### DIFF
--- a/fixtures/packages/paper-button/expected/paper-button.js
+++ b/fixtures/packages/paper-button/expected/paper-button.js
@@ -86,7 +86,6 @@ import { PaperButtonBehavior, PaperButtonBehaviorImpl } from '../../@polymer/pap
 import '../../@polymer/paper-styles/element-styles/paper-material-styles.js';
 import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="paper-button">
   <template strip-whitespace="">

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements-defaults.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/elements-defaults.js
@@ -1,5 +1,4 @@
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<style is="custom-style">
   html {

--- a/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
+++ b/fixtures/packages/polymer/expected/test/smoke/style-props/src/settings.js
@@ -1,7 +1,6 @@
 import { Polymer } from '../../../../lib/legacy/polymer-fn.js';
 import { html } from '../../../../lib/utils/html-tag.js';
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="simple-layout-styles">
   <template>

--- a/fixtures/packages/polymer/expected/test/unit/custom-style-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/custom-style-import.js
@@ -1,6 +1,5 @@
 import './sub/style-import.js';
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="shared-style">
   <template>

--- a/fixtures/packages/polymer/expected/test/unit/shady-unscoped-style-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/shady-unscoped-style-import.js
@@ -1,5 +1,4 @@
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="global-shared1">
   

--- a/fixtures/packages/polymer/expected/test/unit/styling-import-shared-styles.js
+++ b/fixtures/packages/polymer/expected/test/unit/styling-import-shared-styles.js
@@ -1,5 +1,4 @@
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="shared-styles">
   <style>

--- a/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
+++ b/fixtures/packages/polymer/expected/test/unit/sub/resolveurl-elements.js
@@ -11,7 +11,6 @@ import { html } from '../../../lib/utils/html-tag.js';
 
 import { PolymerElement } from '../../../polymer-element.js';
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = `<dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>`;
 document.head.appendChild($_documentContainer.content);
 class PR extends PolymerElement {

--- a/fixtures/packages/polymer/expected/test/unit/sub/style-import.js
+++ b/fixtures/packages/polymer/expected/test/unit/sub/style-import.js
@@ -1,5 +1,4 @@
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="style-import">
   <template>

--- a/src/document-util.ts
+++ b/src/document-util.ts
@@ -544,26 +544,14 @@ export function createDomNodeInsertStatements(
           jsc.memberExpression(
               jsc.identifier(varName), jsc.identifier('innerHTML')),
           templateValue));
-  if (activeInBody) {
-    return [
-      createElementTemplate,
-      setDocumentContainerStatement,
-      jsc.expressionStatement(jsc.callExpression(
-          jsc.memberExpression(
-              jsc.memberExpression(
-                  jsc.identifier('document'), jsc.identifier('body')),
-              jsc.identifier('appendChild')),
-          [jsc.memberExpression(
-              jsc.identifier(varName), jsc.identifier('content'))]))
-    ];
-  }
+  const targetNode = activeInBody ? 'body' : 'head';
   return [
     createElementTemplate,
     setDocumentContainerStatement,
     jsc.expressionStatement(jsc.callExpression(
         jsc.memberExpression(
             jsc.memberExpression(
-                jsc.identifier('document'), jsc.identifier('head')),
+                jsc.identifier('document'), jsc.identifier(targetNode)),
             jsc.identifier('appendChild')),
         [jsc.memberExpression(
             jsc.identifier(varName), jsc.identifier('content'))]))

--- a/src/document-util.ts
+++ b/src/document-util.ts
@@ -530,7 +530,7 @@ export function createDomNodeInsertStatements(
   };
   const templateValue = serializeNodeToTemplateLiteral(fragment as any, false);
 
-  const createElementDiv = jsc.variableDeclaration(
+  const createElementTemplate = jsc.variableDeclaration(
       'const',
       [jsc.variableDeclarator(
           jsc.identifier(varName),
@@ -546,7 +546,7 @@ export function createDomNodeInsertStatements(
           templateValue));
   if (activeInBody) {
     return [
-      createElementDiv,
+      createElementTemplate,
       setDocumentContainerStatement,
       jsc.expressionStatement(jsc.callExpression(
           jsc.memberExpression(
@@ -557,13 +557,8 @@ export function createDomNodeInsertStatements(
               jsc.identifier(varName), jsc.identifier('content'))]))
     ];
   }
-  const setDisplayNoneStatement = jsc.expressionStatement(jsc.callExpression(
-      jsc.memberExpression(
-          jsc.identifier(varName), jsc.identifier('setAttribute')),
-      [jsc.literal('style'), jsc.literal('display: none;')]));
   return [
-    createElementDiv,
-    setDisplayNoneStatement,
+    createElementTemplate,
     setDocumentContainerStatement,
     jsc.expressionStatement(jsc.callExpression(
         jsc.memberExpression(

--- a/src/test/unit/project-converter_test.ts
+++ b/src/test/unit/project-converter_test.ts
@@ -1724,13 +1724,11 @@ Polymer({
         'test.js': `
 import './foo.js';
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = \`<custom-style><style>foo{}</style></custom-style>\`;
 document.head.appendChild($_documentContainer.content);
 `,
         'foo.js': `
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = \`<div>hello world!</div>\`;
 document.head.appendChild($_documentContainer.content);
 `
@@ -1960,7 +1958,6 @@ class BarElem extends Element {}
         'test.js': `
 import { Element } from './polymer.js';
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = \`<div>Top</div><div>Middle</div><div>Bottom</div>\`;
 document.head.appendChild($_documentContainer.content);
 class FooElem extends Element {}
@@ -2001,7 +1998,6 @@ class BarElem extends Element {}
         'test.js': `
 import { Element } from './polymer.js';
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 $_documentContainer.innerHTML = \`<div>Random footer</div>\`;
 document.head.appendChild($_documentContainer.content);
 customElements.define('foo-elem', class FooElem extends Element {
@@ -2579,7 +2575,6 @@ Polymer({
           {
             'test.js': `
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = \`<dom-module>
             <template>
@@ -2713,7 +2708,6 @@ console.log(foo$4);
         -->
     <script type="module">
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = \`<style>
             body { color: red; }
@@ -2723,7 +2717,6 @@ document.head.appendChild($_documentContainer.content);
 </script>
           <script type="module">
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = \`<style is="custom-style" include="foo-bar">
             body { font-size: 10px; }
@@ -2971,7 +2964,6 @@ export const bar = (function() {
       assertSources(await convert(), {
         'test.js': `
 const $_documentContainer = document.createElement('template');
-$_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = \`<dom-module id="dom-module-attr" attr=""></dom-module><dom-module id="multiple-templates">
             <template></template>


### PR DESCRIPTION
Fixing the leftover from #411, really this should have been done there. These template elements are never added to the DOM, only their content is; so let's save a couple of bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-modulizer/457)
<!-- Reviewable:end -->
